### PR TITLE
Arduino Leonardo support

### DIFF
--- a/examples/KeybusReader/KeybusReader.ino
+++ b/examples/KeybusReader/KeybusReader.ino
@@ -122,12 +122,7 @@ void loop() {
 // Prints a timestamp in seconds (with 2 decimal precision) - this is useful to determine when
 // the panel sends a group of messages immediately after each other due to an event.
 void printTimestamp() {
-  float timeStamp = millis() / 1000.0;
-  if (timeStamp < 10) Serial.print("    ");
-  else if (timeStamp < 100) Serial.print("   ");
-  else if (timeStamp < 1000) Serial.print("  ");
-  else if (timeStamp < 10000) Serial.print(" ");
-  Serial.print(timeStamp, 2);
+  Serial.print(millis());
   Serial.print(F(":"));
 }
 


### PR DESCRIPTION
Seems like Arduino Leonardo and other ATmega32U4-based controllers don't have Timer2 thus code does not compile. Use another timer instead.

Also Arduino Leonardo has less space for code so I had to modify KeybusReader sketch to fit.