### PR TITLE
Changes to allow skipping invalid transient  0x05 cmds and wait loop timeouts

### DIFF
--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -117,6 +117,7 @@ class dscKeybusInterface {
     byte openZones[dscZones], openZonesChanged[dscZones];    // Zone status is stored in an array using 1 bit per zone, up to 64 zones
     bool alarmZonesStatusChanged;
     byte alarmZones[dscZones], alarmZonesChanged[dscZones];  // Zone alarm status is stored in an array using 1 bit per zone, up to 64 zones
+    static unsigned long cmdWaitTime; // time to delay treating 05/1b command as valid in ms
 
     // panelData[] and moduleData[] store panel and keypad data in an array: command [0], stop bit by itself [1],
     // followed by the remaining data.  These can be accessed directly in the sketch to get data that is not already
@@ -128,13 +129,13 @@ class dscKeybusInterface {
     //            ^ Byte 1 (stop bit)
     static byte panelData[dscReadSize];
     static volatile byte moduleData[dscReadSize];
-
+	
     // status[] and lights[] store the current status message and LED state for each partition.  These can be accessed
     // directly in the sketch to get data that is not already tracked in the library.  See printPanelMessages() and
     // printPanelLights() in dscKeybusPrintData.cpp to see how this data translates to the status message and LED status.
     byte status[dscPartitions];
     byte lights[dscPartitions];
-
+    
     // Process keypad and module data, returns true if data is available
     bool handleModule();
 
@@ -241,17 +242,18 @@ class dscKeybusInterface {
     bool writeArm[dscPartitions];
     bool queryResponse;
     bool previousTrouble;
+	
     bool previousKeybus;
     byte previousAccessCode[dscPartitions];
     byte previousLights[dscPartitions], previousStatus[dscPartitions];
     bool previousReady[dscPartitions];
-    bool previousExitDelay[dscPartitions], previousEntryDelay[dscPartitions];
+	bool previousExitDelay[dscPartitions], previousEntryDelay[dscPartitions];
     byte previousExitState[dscPartitions];
     bool previousArmed[dscPartitions], previousArmedStay[dscPartitions];
     bool previousAlarm[dscPartitions];
     bool previousFire[dscPartitions];
     byte previousOpenZones[dscZones], previousAlarmZones[dscZones];
-
+	
     static byte dscClockPin;
     static byte dscReadPin;
     static byte dscWritePin;
@@ -262,7 +264,7 @@ class dscKeybusInterface {
     static volatile bool writeKeyPending;
     static volatile bool writeAlarm, writeAsterisk, wroteAsterisk;
     static volatile bool moduleDataCaptured;
-    static volatile unsigned long clockHighTime, keybusTime;
+	static volatile unsigned long clockHighTime, keybusTime;
     static volatile byte panelBufferLength;
     static volatile byte panelBuffer[dscBufferSize][dscReadSize];
     static volatile byte panelBufferBitCount[dscBufferSize], panelBufferByteCount[dscBufferSize];

--- a/src/dscKeybusProcessData.cpp
+++ b/src/dscKeybusProcessData.cpp
@@ -24,7 +24,7 @@
 void dscKeybusInterface::resetStatus() {
   statusChanged = true;
   keybusChanged = true;
-  troubleChanged = true;
+  //troubleChanged = true;
   powerChanged = true;
   batteryChanged = true;
   for (byte partition = 0; partition < dscPartitions; partition++) {
@@ -32,7 +32,9 @@ void dscKeybusInterface::resetStatus() {
     armedChanged[partition] = true;
     alarmChanged[partition] = true;
     fireChanged[partition] = true;
+	troubleChanged = true;
     disabled[partition] = true;
+	
   }
   openZonesStatusChanged = true;
   alarmZonesStatusChanged = true;
@@ -41,7 +43,6 @@ void dscKeybusInterface::resetStatus() {
     alarmZonesChanged[zoneGroup] = 0xFF;
   }
 }
-
 
 // Sets the panel time
 bool dscKeybusInterface::setTime(unsigned int year, byte month, byte day, byte hour, byte minute, const char* accessCode) {
@@ -95,6 +96,7 @@ bool dscKeybusInterface::setTime(unsigned int year, byte month, byte day, byte h
 // Processes status commands: 0x05 (Partitions 1-4) and 0x1B (Partitions 5-8)
 void dscKeybusInterface::processPanelStatus() {
 
+
   // Trouble status
   if (panelData[3] <= 0x05) {  // Ignores trouble light status in intermittent states
     if (bitRead(panelData[2],4)) trouble = true;
@@ -131,7 +133,7 @@ void dscKeybusInterface::processPanelStatus() {
       statusByte = ((partitionIndex - 4) * 2) + 2;
       messageByte = ((partitionIndex - 4) * 2) + 3;
     }
-
+	
     // Partition disabled status
     if (panelData[messageByte] == 0xC7) disabled[partitionIndex] = true;
     else disabled[partitionIndex] = false;
@@ -152,7 +154,8 @@ void dscKeybusInterface::processPanelStatus() {
 
     // Fire status
     if (panelData[messageByte] < 0x12) {  // Ignores fire light status in intermittent states
-      if (bitRead(panelData[statusByte],6)) fire[partitionIndex] = true;
+     if (bitRead(panelData[statusByte],6)) fire[partitionIndex] = true;
+	
       else fire[partitionIndex] = false;
       if (fire[partitionIndex] != previousFire[partitionIndex]) {
         previousFire[partitionIndex] = fire[partitionIndex];
@@ -160,7 +163,7 @@ void dscKeybusInterface::processPanelStatus() {
         if (!pauseStatus) statusChanged = true;
       }
     }
-
+	
 
     // Messages
     switch (panelData[messageByte]) {
@@ -168,20 +171,20 @@ void dscKeybusInterface::processPanelStatus() {
       // Ready
       case 0x01:         // Partition ready
       case 0x02: {       // Stay/away zones open
-        ready[partitionIndex] = true;
+	    ready[partitionIndex] = true;
         if (ready[partitionIndex] != previousReady[partitionIndex]) {
           previousReady[partitionIndex] = ready[partitionIndex];
           readyChanged[partitionIndex] = true;
           if (!pauseStatus) statusChanged = true;
         }
-
+		noEntryDelay[partitionIndex] = false;
         entryDelay[partitionIndex] = false;
         if (entryDelay[partitionIndex] != previousEntryDelay[partitionIndex]) {
           previousEntryDelay[partitionIndex] = entryDelay[partitionIndex];
           entryDelayChanged[partitionIndex] = true;
           if (!pauseStatus) statusChanged = true;
         }
-
+		
         armedStay[partitionIndex] = false;
         armedAway[partitionIndex] = false;
         armed[partitionIndex] = false;
@@ -208,7 +211,7 @@ void dscKeybusInterface::processPanelStatus() {
           readyChanged[partitionIndex] = true;
           if (!pauseStatus) statusChanged = true;
         }
-
+		noEntryDelay[partitionIndex] = false;
         entryDelay[partitionIndex] = false;
         if (entryDelay[partitionIndex] != previousEntryDelay[partitionIndex]) {
           previousEntryDelay[partitionIndex] = entryDelay[partitionIndex];
@@ -221,7 +224,8 @@ void dscKeybusInterface::processPanelStatus() {
       // Armed
       case 0x04:         // Armed stay
       case 0x05: {       // Armed away
-        if (panelData[messageByte] == 0x04) {
+	    writeArm[partitionIndex] = false;
+	    if (panelData[messageByte] == 0x04) {
           armedStay[partitionIndex] = true;
           armedAway[partitionIndex] = false;
         }
@@ -229,17 +233,15 @@ void dscKeybusInterface::processPanelStatus() {
           armedStay[partitionIndex] = false;
           armedAway[partitionIndex] = true;
         }
-
-        writeArm[partitionIndex] = false;
-
-        armed[partitionIndex] = true;
+		armed[partitionIndex] = true;
+       
         if (armed[partitionIndex] != previousArmed[partitionIndex] || armedStay[partitionIndex] != previousArmedStay[partitionIndex]) {
           previousArmed[partitionIndex] = armed[partitionIndex];
           previousArmedStay[partitionIndex] = armedStay[partitionIndex];
           armedChanged[partitionIndex] = true;
           if (!pauseStatus) statusChanged = true;
         }
-
+	  
         ready[partitionIndex] = false;
         if (ready[partitionIndex] != previousReady[partitionIndex]) {
           previousReady[partitionIndex] = ready[partitionIndex];
@@ -269,7 +271,6 @@ void dscKeybusInterface::processPanelStatus() {
       case 0x08: {
         writeArm[partitionIndex] = false;
         accessCodePrompt = false;
-
         exitDelay[partitionIndex] = true;
         if (exitDelay[partitionIndex] != previousExitDelay[partitionIndex]) {
           previousExitDelay[partitionIndex] = exitDelay[partitionIndex];
@@ -299,7 +300,7 @@ void dscKeybusInterface::processPanelStatus() {
 
       // Arming with no entry delay
       case 0x09: {
-        ready[partitionIndex] = true;
+		ready[partitionIndex] = true;
         if (ready[partitionIndex] != previousReady[partitionIndex]) {
           previousReady[partitionIndex] = ready[partitionIndex];
           readyChanged[partitionIndex] = true;
@@ -343,7 +344,7 @@ void dscKeybusInterface::processPanelStatus() {
           entryDelayChanged[partitionIndex] = true;
           if (!pauseStatus) statusChanged = true;
         }
-
+	  
         alarm[partitionIndex] = true;
         if (alarm[partitionIndex] != previousAlarm[partitionIndex]) {
           previousAlarm[partitionIndex] = alarm[partitionIndex];
@@ -351,23 +352,23 @@ void dscKeybusInterface::processPanelStatus() {
           if (!pauseStatus) statusChanged = true;
         }
         break;
-      }
-
+     
+	  }
       // Arming with bypassed zones
       case 0x15: {
         ready[partitionIndex] = true;
-        if (ready[partitionIndex] != previousReady[partitionIndex]) {
+		if (ready[partitionIndex] != previousReady[partitionIndex]) {
           previousReady[partitionIndex] = ready[partitionIndex];
           readyChanged[partitionIndex] = true;
           if (!pauseStatus) statusChanged = true;
-        }
+	    }
         break;
       }
 
       // Partition armed with no entry delay
+	  case 0x06:
       case 0x16: {
         noEntryDelay[partitionIndex] = true;
-
         // Sets an armed mode if not already set, used if interface is initialized while the panel is armed
         if (!armedStay[partitionIndex] && !armedAway[partitionIndex]) armedStay[partitionIndex] = true;
 
@@ -386,8 +387,12 @@ void dscKeybusInterface::processPanelStatus() {
           if (!pauseStatus) statusChanged = true;
         }
         break;
-      }
-
+      
+	  }
+      
+      // possible power failure. Do not set state unavailable
+	  case 0x17: break; 
+      
       // Partition disarmed
       case 0x3D:
       case 0x3E: {
@@ -408,15 +413,15 @@ void dscKeybusInterface::processPanelStatus() {
         }
 
         exitState[partitionIndex] = 0;
-
+		noEntryDelay[partitionIndex] = false;
         entryDelay[partitionIndex] = false;
         if (entryDelay[partitionIndex] != previousEntryDelay[partitionIndex]) {
           previousEntryDelay[partitionIndex] = entryDelay[partitionIndex];
           entryDelayChanged[partitionIndex] = true;
           if (!pauseStatus) statusChanged = true;
         }
-
-        armedStay[partitionIndex] = false;
+		
+	    armedStay[partitionIndex] = false;
         armedAway[partitionIndex] = false;
         armed[partitionIndex] = false;
         if (armed[partitionIndex] != previousArmed[partitionIndex]) {
@@ -437,7 +442,7 @@ void dscKeybusInterface::processPanelStatus() {
       // Invalid access code
       case 0x8F: {
         if (!armed[partitionIndex]) {
-        ready[partitionIndex] = true;
+          ready[partitionIndex] = true;
           if (ready[partitionIndex] != previousReady[partitionIndex]) {
             previousReady[partitionIndex] = ready[partitionIndex];
             readyChanged[partitionIndex] = true;
@@ -452,6 +457,7 @@ void dscKeybusInterface::processPanelStatus() {
         wroteAsterisk = false;  // Resets the flag that delays writing after '*' is pressed
         writeAsterisk = false;
         writeKeyPending = false;
+		
         ready[partitionIndex] = false;
         if (ready[partitionIndex] != previousReady[partitionIndex]) {
           previousReady[partitionIndex] = ready[partitionIndex];
@@ -462,7 +468,7 @@ void dscKeybusInterface::processPanelStatus() {
       }
 
       // Enter access code
-      case 0x9F: {
+	    case 0x9F: {
         if (writeArm[partitionIndex]) {  // Ensures access codes are only sent when an arm command is sent through this interface
           accessCodePrompt = true;
           if (!pauseStatus) statusChanged = true;
@@ -476,18 +482,20 @@ void dscKeybusInterface::processPanelStatus() {
         }
         break;
       }
-
+	 
       default: {
-        ready[partitionIndex] = false;
-        if (ready[partitionIndex] != previousReady[partitionIndex]) {
-          previousReady[partitionIndex] = ready[partitionIndex];
-          readyChanged[partitionIndex] = true;
-          if (!pauseStatus) statusChanged = true;
-        }
+		ready[partitionIndex] = false;
+		if (ready[partitionIndex] != previousReady[partitionIndex]) {
+		previousReady[partitionIndex] = ready[partitionIndex];
+		readyChanged[partitionIndex] = true;
+		if (!pauseStatus) statusChanged = true;
+	  }
         break;
       }
     }
+	
   }
+  
 }
 
 
@@ -501,7 +509,6 @@ void dscKeybusInterface::processPanel_0x27() {
 
     // Armed
     if (panelData[messageByte] == 0x04 || panelData[messageByte] == 0x05) {
-
       ready[partitionIndex] = false;
       if (ready[partitionIndex] != previousReady[partitionIndex]) {
         previousReady[partitionIndex] = ready[partitionIndex];
@@ -534,12 +541,11 @@ void dscKeybusInterface::processPanel_0x27() {
       }
 
       exitState[partitionIndex] = 0;
-    }
+	}
 
     // Armed with no entry delay
-    else if (panelData[messageByte] == 0x16) {
-      noEntryDelay[partitionIndex] = true;
-
+    else if (panelData[messageByte] == 0x16 || panelData[messageByte] == 0x06) {
+	  noEntryDelay[partitionIndex] = true;
       // Sets an armed mode if not already set, used if interface is initialized while the panel is armed
       if (!armedStay[partitionIndex] && !armedAway[partitionIndex]) armedStay[partitionIndex] = true;
 
@@ -803,6 +809,7 @@ void dscKeybusInterface::processPanelStatus0(byte partition, byte panelByte) {
     armedAway[partitionIndex] = false;
     armedStay[partitionIndex] = false;
     armed[partitionIndex] = false;
+
     if (armed[partitionIndex] != previousArmed[partitionIndex]) {
       previousArmed[partitionIndex] = armed[partitionIndex];
       armedChanged[partitionIndex] = true;
@@ -1037,6 +1044,7 @@ void dscKeybusInterface::processPanelStatus2(byte partition, byte panelByte) {
 
       // Armed with no entry delay
       case 0x9C: {
+		  
         noEntryDelay[partitionIndex] = true;
 
         ready[partitionIndex] = false;


### PR DESCRIPTION
- Add delay timer to filter out short duration 05 cmds that some panels such as the 5005 send periodically.
- Add timer to exit out of 9B wait loop after a * cmd is sent to prevent
system lockup when a cmd is sent to an inactive partion which never
responds with the 9B
- Add 05 status 06 (noentry delay) and 17 (ac power failure) sent by
some panels

The main reason for this was that a certain user pc5005 panel a user had, would intermittently send short duration odd 0x05 messages/status that did not make any sense.  The only way that I could find to filter them out is to add logic that would allow us to set a set valid time that a command needs to be seen before it is treated as valid.  Anything shorter is disregarded.   This works very well.  Setting a value of 0, skips the very first command then accepts the following one. 