### PR TITLE
Added sanity checks and configs for systems with systems with 32 zones maximum support

### DIFF
--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -99,7 +99,7 @@ dscKeybusInterface::dscKeybusInterface(byte setClockPin, byte setReadPin, byte s
   writePartition = 1;
   pauseStatus = false;
   maxZones=32;
-  panelVersion=3; //newer.  Version 2 uses older alternate zone addressing
+  panelVersion=2; //newer.  Version 2 uses older alternate zone addressing
   maxFields05=4;
   maxFields11=4;
 
@@ -263,7 +263,13 @@ bool dscKeybusInterface::loop() {
         if (panelByteCount < 9) {
             maxFields05=4; 
             maxFields11=4; 
+            panelVersion=2;
+        } else {
+            maxFields05=6; 
+            maxFields11=6; 
+            panelVersion=3;
         }
+            
   
     }
     else return false;
@@ -304,7 +310,6 @@ bool dscKeybusInterface::loop() {
     static byte previousCmdC3[dscReadSize];
     switch (panelData[0]) {
       case 0x11:  // Keypad slot query
-      
         if (redundantPanelData(previousCmd11, panelData)) return true;
         break;
 
@@ -377,6 +382,7 @@ bool dscKeybusInterface::handleModule() {
 
   // Skips periodic keypad slot query responses
   if (!processRedundantData && currentCmd == 0x11) {
+    
     bool redundantData = false;
     byte checkedBytes = dscReadSize;
     static byte previousSlotData[dscReadSize];

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -383,7 +383,7 @@ bool dscKeybusInterface::handleModule() {
   // Skips periodic keypad slot query responses
   if (!processRedundantData && currentCmd == 0x11) {
     
-    bool redundantData = false;
+    bool redundantData = true;
     byte checkedBytes = dscReadSize;
     static byte previousSlotData[dscReadSize];
     for (byte i = 0; i < checkedBytes; i++) {
@@ -739,7 +739,7 @@ for (int x=0;x<moduleIdx;x++) {
 }
 
 void dscKeybusInterface::addModule(byte address) {
- //this is the main filter to block invalid device addresses.  
+ if (!address) return;
 
  if (moduleIdx < maxModules ) {
     modules[moduleIdx].address=address;
@@ -846,11 +846,10 @@ void dscKeybusInterface::setZoneFault(byte zone,bool fault) {
          modules[idx].fields[3]=modules[idx].fields[2];  //copy current channel values to previous
          change=true;
     }
-
     if (!change) return;  //nothing changed in our zones so return
     if (modules[idx].zoneStatusByte) {
         pendingZoneStatus[modules[idx].zoneStatusByte]&=modules[idx].zoneStatusMask; //set update slot
-        addRequestToQueue(idx);  //update queue to indicate pending request
+        addRequestToQueue(address);  //update queue to indicate pending request
     }
 }
  

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -724,7 +724,7 @@ void dscKeybusInterface::addModule(byte address) {
 }
 
 void dscKeybusInterface::addRelayModule() {
-    setSupervisorySlot(16,true);
+    setSupervisorySlot(18,true);
 }
 
 void dscKeybusInterface::removeModule(byte address) {

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -269,8 +269,9 @@ bool dscKeybusInterface::loop() {
             maxFields11=6; 
             panelVersion=3;
         }
-            
-  
+     //ok we should know what panel version and zones we have so we can init the module data with the correct slot info
+     updateModules();
+
     }
     else return false;
   }
@@ -738,19 +739,25 @@ for (int x=0;x<moduleIdx;x++) {
       }
 }
 
-void dscKeybusInterface::addModule(byte address) {
- if (!address) return;
-
- if (moduleIdx < maxModules ) {
-    modules[moduleIdx].address=address;
-    for (int x=0;x<4;x++) modules[moduleIdx].fields[x]=0x55;//set our zones as closed by default (01 per channel)
-    //fetch the byte offset and mask for the 0x05 request to update response and store it with the module data
-    zoneMaskType zm=getUpdateMask(address);
-    modules[moduleIdx].zoneStatusByte=zm.idx;
-    modules[moduleIdx].zoneStatusMask=zm.mask;
-    setSupervisorySlot(address,true);
-    moduleIdx++;
+//once we know what panelversion we have, we can then update the modules with the correct info here
+void dscKeybusInterface::updateModules() {
+    for (int x=0;x<moduleIdx;x++) {
+        zoneMaskType zm=getUpdateMask(modules[x].address);
+        modules[x].zoneStatusByte=zm.idx;
+        modules[x].zoneStatusMask=zm.mask;
+        setSupervisorySlot(modules[x].address,true);
     }
+}
+
+//add new expander modules and init zone fields
+void dscKeybusInterface::addModule(byte address) {
+    
+ if (!address) return;
+ if (moduleIdx < maxModules ) {
+   modules[moduleIdx].address=address;
+   for (int x=0;x<4;x++) modules[moduleIdx].fields[x]=0x55;//set our zones as closed by default (01 per channel)
+   moduleIdx++;
+ }
 }
 
 void dscKeybusInterface::addRelayModule() {

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -650,6 +650,27 @@ byte  IRAM_ATTR dscKeybusInterface::getPendingUpdate() {
 
 void dscKeybusInterface::setSupervisorySlot(byte address,bool set=true) {
        //set our response data for the 0x11 supervisory request
+       if (panelVersion < 3) {
+            switch (address) {
+            //11111111 1 00111111 11111111 11111111 11111111 11111111 11111100 11111111 16
+            //11111111 1 00111111 11111111 11111111 00111111 11111111 11111111 11111111 13
+            // 1111111 1 00111111 11111111 00111111 11111111 11111111 11111111 11111111 slots 9
+            //11111111 1 00111111 11111111 11111111 11111111 11111111 11111100 11111111 slots 16
+             //for older versions we need to set 2 slots since they expect groups of 4 zones per slot
+            case 9:   moduleSlots[2]=set?moduleSlots[2]&0x3f:moduleSlots[2]|~0x3f; //pc5108 
+                      moduleSlots[2]=set?moduleSlots[2]&0xcf:moduleSlots[2]|~0xcf;
+                      break; 
+            case 10:  moduleSlots[2]=set?moduleSlots[2]&0xf3:moduleSlots[2]|~0xf3; //pc5108
+                      moduleSlots[2]=set?moduleSlots[2]&0xfc:moduleSlots[2]|~0xfc;
+                      break; 
+            case 11:  moduleSlots[3]=set?moduleSlots[3]&0x3f:moduleSlots[3]|~0x3f;//pc5108
+                      moduleSlots[3]=set?moduleSlots[3]&0xcf:moduleSlots[3]|~0xcf;
+                      break; 
+            case 18:  moduleSlots[3]=set?moduleSlots[3]&0xfc:moduleSlots[3]|~0xfc;break;  // pc5208 relay board reports as 18
+            default: return;
+        }
+           
+       } else {
         switch (address) {
             //11111111 1 00111111 11111111 11111111 11111111 11111111 11111100 11111111 16
             //11111111 1 00111111 11111111 11111111 00111111 11111111 11111111 11111111 13
@@ -658,15 +679,15 @@ void dscKeybusInterface::setSupervisorySlot(byte address,bool set=true) {
             case 9:   moduleSlots[2]=set?moduleSlots[2]&0x3f:moduleSlots[2]|~0x3f;break; //pc5108 
             case 10:  moduleSlots[2]=set?moduleSlots[2]&0xcf:moduleSlots[2]|~0xcf;break; //pc5108
             case 11:  moduleSlots[2]=set?moduleSlots[2]&0xf3:moduleSlots[2]|~0xf3;break; //pc5108
-            case 12:  moduleSlots[2]=set?moduleSlots[2]&0xfc:moduleSlots[2]|~0xfc;break; //pc5108
-            case 13:  moduleSlots[3]=set?moduleSlots[3]&0x3f:moduleSlots[3]|~0x3f;break; //pc5108
-            case 14:  moduleSlots[3]=set?moduleSlots[3]&0xcf:moduleSlots[3]|~0xcf;break; //pc5108
-            case 16:  moduleSlots[5]=set?moduleSlots[5]&0x3f:moduleSlots[5]|~0x3f;break; //pc5108 (shows on slot24)// reports as 16 in panel
+            case 12:  if  (maxZones>32) {moduleSlots[2]=set?moduleSlots[2]&0xfc:moduleSlots[2]|~0xfc;}break; //pc5108
+            case 13:  if  (maxZones>32) {moduleSlots[3]=set?moduleSlots[3]&0x3f:moduleSlots[3]|~0x3f;}break; //pc5108
+            case 14:  if  (maxZones>32) {moduleSlots[3]=set?moduleSlots[3]&0xcf:moduleSlots[3]|~0xcf;}break; //pc5108
+            case 16:  if  (maxZones>32) {moduleSlots[5]=set?moduleSlots[5]&0x3f:moduleSlots[5]|~0x3f;}break; //pc5108 (shows on slot24)// reports as 16 in panel
             //reports as 18 in panel
             case 18:  moduleSlots[3]=set?moduleSlots[3]&0xfc:moduleSlots[3]|~0xfc;break;  // pc5208 relay board reports as 18
             default: return;
         }
-    
+       }
     
 }
 
@@ -680,15 +701,18 @@ zoneMaskType dscKeybusInterface::getUpdateMask(byte address) {
         //get our request byte and mask to send data for the zone that we need to publish info on. This gets sent on the 05 command
         //11111111 1 11111111 11111111 11111111 11111111 11111111 01111111 11111111 11111111 (12)
         //11111111 1 11111111 11111111 10111111 11111111 11111111 11111111 11111111 11111111 (9)
+        //11111111 1 11111111 11111111 10111111 11111111 version 2 zone 9 -16
+        //11111111 1 11111111 11111111 11101111 11111111  version 2 system zone 27-32
+
         zoneMaskType zm;
         switch (address) {
             case 9:  zm.idx=2;zm.mask=0xbf; break; //5208
             case 10: zm.idx=2;zm.mask=0xdf; break; //5208
             case 11: zm.idx=2;zm.mask=0xef; break;//5208
-            case 12: if (panelVersion>=3) {zm.idx=5;zm.mask=0x7f;} else {zm.idx=2;zm.mask=0xf7;}; break;
-            case 13: if (panelVersion>=3) {zm.idx=5;zm.mask=0xbf;} else {zm.idx=2;zm.mask=0xfb;}; break;
-            case 14: if (panelVersion>=3) {zm.idx=5;zm.mask=0xdf;} else {zm.idx=2;zm.mask=0xfd;}; break;
-            case 16: if (panelVersion>=3) {zm.idx=5;zm.mask=0xef;} break;//5208 sends to slot 15
+            case 12: if (maxZones>32) {zm.idx=5;zm.mask=0x7f;} break;
+            case 13: if (maxZones>32) {zm.idx=5;zm.mask=0xbf;} break;
+            case 14: if (maxZones>32) {zm.idx=5;zm.mask=0xdf;} break;
+            case 16: if (maxZones>32) {zm.idx=5;zm.mask=0xef;} break;//5208 sends to slot 15
             case 18: zm.idx=2;zm.mask=0xfe; break; //relay board 5108 sends to slot 16
         }
         return zm;
@@ -748,7 +772,6 @@ void dscKeybusInterface::setZoneFault(byte zone,bool fault) {
     
     if (zone > maxZones) return;
     
-    if (panelVersion >= 3) { 
     //get address and channel from zone range
         if (zone > 8 && zone < 17) {
             address=9;
@@ -773,27 +796,7 @@ void dscKeybusInterface::setZoneFault(byte zone,bool fault) {
             channel=zone-57;
         } 
     
-    } else { 
-        if (zone > 8 && zone < 13) {
-            address=9;
-            channel=zone-9;
-        } else if (zone > 12 && zone < 17) {
-            address=10;
-            channel=zone-13;
-        } else if (zone > 16 && zone < 21) {
-            address=11;
-            channel=zone-17;
-        } else if (zone > 20 && zone < 25) {
-            address=12;
-            channel=zone-21;
-        } else if (zone > 24 && zone < 29) {
-            address=13;
-            channel=zone-25;
-        } else if (zone > 28 && zone < 33) {
-            address=14;
-            channel=zone-29;
-        } 
-    }
+     
     
     if (!address ) return; //invalid zone, so return
  
@@ -803,10 +806,14 @@ void dscKeybusInterface::setZoneFault(byte zone,bool fault) {
     for (idx=0;idx<moduleIdx;idx++) {
         if (modules[idx].address==address) break;
     }
+
     if (idx==moduleIdx) return;  //address not found in our emulation list so return
     
     uint8_t chk1=0xff;
     uint8_t chk2=0xff;
+           
+
+    
     if (channel < 4) { //set / reset bits according to fault value (open=11,closed=01)
         channel=channel*2;
         modules[idx].fields[0]=fault?modules[idx].fields[0] | (zoneOpen << channel):modules[idx].fields[0] & ~(zoneClosed << channel);
@@ -835,9 +842,10 @@ void dscKeybusInterface::setZoneFault(byte zone,bool fault) {
     }
 
     if (!change) return;  //nothing changed in our zones so return
-    pendingZoneStatus[modules[idx].zoneStatusByte]&=modules[idx].zoneStatusMask; //set update slot
-    addRequestToQueue(idx);  //update queue to indicate pending request
- 
+    if (modules[idx].zoneStatusByte) {
+        pendingZoneStatus[modules[idx].zoneStatusByte]&=modules[idx].zoneStatusMask; //set update slot
+        addRequestToQueue(idx);  //update queue to indicate pending request
+    }
 }
  
 #if defined(__AVR__)

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -217,7 +217,9 @@ class dscKeybusInterface {
     void printPanel_0x27();
     void printPanel_0x28();
     void printPanel_0x2D();
+    void printPanel_0x33();
     void printPanel_0x34();
+    void printPanel_0x39();    
     void printPanel_0x3E();
     void printPanel_0x4C();
     void printPanel_0x58();
@@ -240,9 +242,13 @@ class dscKeybusInterface {
     void printPanel_0xD5();
     void printPanel_0xE6();
     void printPanel_0xE6_0x03();
+    void printPanel_0xE6_0x08();    
     void printPanel_0xE6_0x09();
+    void printPanel_0xE6_0x0A();    
     void printPanel_0xE6_0x0B();
+    void printPanel_0xE6_0x0C();    
     void printPanel_0xE6_0x0D();
+    void printPanel_0xE6_0x0E();    
     void printPanel_0xE6_0x0F();
     void printPanel_0xE6_0x17();
     void printPanel_0xE6_0x18();

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -148,7 +148,7 @@ class dscKeybusInterface {
     void addModule(byte address); //add zone expanders
     void addRelayModule(); 
     void clearZoneRanges();
-    byte maxZones;
+    static byte maxZones;
     
     // panelData[] and moduleData[] store panel and keypad data in an array: command [0], stop bit by itself [1],
     // followed by the remaining data.  These can be accessed directly in the sketch to get data that is not already

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -146,6 +146,7 @@ class dscKeybusInterface {
     bool relayStatusChanged;
     byte relayChannels,previousRelayChannels;
     void addModule(byte address); //add zone expanders
+    void updateModules();
     void addRelayModule(); 
     void clearZoneRanges();
     static byte maxZones;

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -33,7 +33,7 @@ const byte updateQueueSize=5; //zone pending update queue
 const byte dscPartitions = 8;
 const byte dscZones = 8;
 const byte dscBufferSize = 50;
-const byte maxModules = 10;
+const byte maxModules = 4;
 const byte updateQueueSize=10; //zone pending update queue
 
 #endif
@@ -149,6 +149,7 @@ class dscKeybusInterface {
     void addRelayModule(); 
     void clearZoneRanges();
     static byte maxZones;
+    static byte panelVersion;
     
     // panelData[] and moduleData[] store panel and keypad data in an array: command [0], stop bit by itself [1],
     // followed by the remaining data.  These can be accessed directly in the sketch to get data that is not already
@@ -291,7 +292,6 @@ class dscKeybusInterface {
     bool queryResponse;
     static byte maxFields05; 
     static byte maxFields11;
-    byte maxDeviceAddress;
 	
     bool previousKeybus;
     byte previousAccessCode[dscPartitions];

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -1685,13 +1685,13 @@ void dscKeybusInterface::printPanel_0xE6() {
 
   switch (panelData[2]) {
     case 0x03: printPanel_0xE6_0x03(); break;  // Status in alarm/programming, partitions 5-8
-    case 0x08: printPanel_0xE6_0x08(); break;  // Zone expander zones 33-40 query
+  //  case 0x08: printPanel_0xE6_0x08(); break;  // Zone expander zones 33-40 query
     case 0x09: printPanel_0xE6_0x09(); break;  // Zones 33-40 status
-    case 0x0A: printPanel_0xE6_0x0A(); break;  // Zone expander zones 41-48 query
+  //  case 0x0A: printPanel_0xE6_0x0A(); break;  // Zone expander zones 41-48 query
     case 0x0B: printPanel_0xE6_0x0B(); break;  // Zones 41-48 status
-    case 0x0C: printPanel_0xE6_0x0C(); break;  // Zone expander zones 49-56 query
+   // case 0x0C: printPanel_0xE6_0x0C(); break;  // Zone expander zones 49-56 query
     case 0x0D: printPanel_0xE6_0x0D(); break;  // Zones 49-56 status
-    case 0x0E: printPanel_0xE6_0x0E(); break;  // Zone expander zones 57-64 query
+   // case 0x0E: printPanel_0xE6_0x0E(); break;  // Zone expander zones 57-64 query
     case 0x0F: printPanel_0xE6_0x0F(); break;  // Zones 57-64 status
     case 0x17: printPanel_0xE6_0x17(); break;  // Flash panel lights: status and zones 1-32, partitions 1-8
     case 0x18: printPanel_0xE6_0x18(); break;  // Flash panel lights: status and zones 33-64, partitions 1-8


### PR DESCRIPTION
Tested with my older PC5010 panel which has the smaller 05/11 cmds and only 32zone support . Used a config and some code that looks at the lenght of the 05 command and adjusts accordingly  Code works ok for zones. It does support zones in groups of 8.    Trying to use more than 32 zones will be ignored.  

Still more testing needed though for smaller systems.