### PR TITLE
Expander updates to optimize IRAM memory and fix issues with 05/1b commands

### DIFF
--- a/examples/esp8266/Unlocker/Unlocker.ino
+++ b/examples/esp8266/Unlocker/Unlocker.ino
@@ -646,7 +646,7 @@ void loop() {
       dsc.write('0');
 
       // Loops until the panel sends a status command (0x05) or a long beep command (0x7F)
-      while (dsc.panelData[0] != 0x05 && dsc.panelData[0] != 0x7F) {
+     while (dsc.panelData[0] != 0x05 && dsc.panelData[0] != 0x7F && dsc.panelData[0] != 0xE6) {
         dsc.loop();
         yield();
       }
@@ -660,7 +660,7 @@ void loop() {
       }
 
       // Entered keypad programming, code is valid - exits the installer menu and outputs the code via serial and LED blinking
-      else if (dsc.status[0] == 0xF8) {
+      else if (dsc.status[0] == 0xF8 || dsc.status[0] == 0xE4 ) {
         printTimestamp();
         Serial.print("Installer code: ");
         Serial.println(testCode);

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -1029,14 +1029,14 @@ void IRAM_ATTR dscKeybusInterface::dscClockInterrupt() {
           }
         }
       }
-
+      
       // Writes a regular key unless waiting for a response to the '*' key or the panel is sending a query command
-      else if ( writeKeyPending && !wroteAsterisk && isrPanelByteCount == writeByte && writeCmd) {
+      //else if ( writeKeyPending && !wroteAsterisk && isrPanelByteCount == writeByte && writeCmd) {
+       else if ( writeKeyPending && !wroteAsterisk && writeCmd) {
         // Writes the first bit by shifting the key data right 7 bits and checking bit 0
         if (isrPanelBitTotal == writeBit || (writeStart && isrPanelBitTotal > writeBit && isrPanelBitTotal <= writeBit + 7)) {
           writeStart=true; // Resolves a timing issue where some writes do not begin at the correct bit
           if (!((writeKey >> (7 - isrPanelBitCount)) & 0x01)) digitalWrite(dscWritePin, HIGH);
-
           // Resets counters when the write is complete
           if (isrPanelBitTotal == writeBit + 7) {
             if (writeAsterisk) wroteAsterisk = true;  // Delays writing after pressing '*' until the panel is ready
@@ -1045,8 +1045,7 @@ void IRAM_ATTR dscKeybusInterface::dscClockInterrupt() {
           }
         }
       } 
-      else if (isrPanelData[0]==moduleCmd && writeModulePending ) {
-        // Writes the first bit by shifting the key data right 7 bits and checking bit 0
+      else if (isrPanelData[0]==moduleCmd && writeModulePending && !wroteAsterisk ) {
         if (isrPanelBitTotal == writeModuleBit || (writeStart && isrPanelBitTotal > writeModuleBit && isrPanelBitTotal <= writeModuleBit + (moduleBufferLength * 8))) {
            writeStart=true;
           if (!((writeModuleBuffer[currentModuleIdx] >> (7 - isrPanelBitCount)) & 0x01)) digitalWrite(dscWritePin, HIGH);
@@ -1096,7 +1095,6 @@ void IRAM_ATTR dscKeybusInterface::dscDataInterrupt() {
 
   static bool skipData = false;
   static bool skipFirst = false;
-//  static unsigned long cmdTime;
 
   // Panel sends data while the clock is high
   if (digitalRead(dscClockPin) == HIGH) {
@@ -1211,7 +1209,7 @@ void IRAM_ATTR dscKeybusInterface::dscDataInterrupt() {
                   skipFirst=false;
               } else 
                   skipData=true;
-          } else if (debounce05) { // we skip the first cmd to remove spurious invalid ones during a changeover. Reported by on a pc5005
+          } else if (debounce05) { // we skip the first cmd to remove spurious invalid ones during a changeover. Reported on a pc5005
                skipData=true;
                skipFirst=true;
            }

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -1031,8 +1031,8 @@ void IRAM_ATTR dscKeybusInterface::dscClockInterrupt() {
       }
       
       // Writes a regular key unless waiting for a response to the '*' key or the panel is sending a query command
-      //else if ( writeKeyPending && !wroteAsterisk && isrPanelByteCount == writeByte && writeCmd) {
-       else if ( writeKeyPending && !wroteAsterisk && writeCmd) {
+      else if ( writeKeyPending && !wroteAsterisk && isrPanelByteCount == writeByte && writeCmd) {
+       //else if ( writeKeyPending && !wroteAsterisk && writeCmd) {
         // Writes the first bit by shifting the key data right 7 bits and checking bit 0
         if (isrPanelBitTotal == writeBit || (writeStart && isrPanelBitTotal > writeBit && isrPanelBitTotal <= writeBit + 7)) {
           writeStart=true; // Resolves a timing issue where some writes do not begin at the correct bit

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -315,7 +315,7 @@ bool dscKeybusInterface::loop() {
     static byte previousCmdC3[dscReadSize];
     switch (panelData[0]) {
       case 0x11:  // Keypad slot query
-        if (redundantPanelData(previousCmd11, panelData)) return true;
+        if (redundantPanelData(previousCmd11, panelData)) return false;
         break;
 
       case 0x16:  // Zone wiring
@@ -629,7 +629,7 @@ bool  IRAM_ATTR dscKeybusInterface::redundantPanelData(byte previousCmd[], volat
     for (byte i = 0; i < dscReadSize; i++) previousCmd[i] = currentCmd[i];
     return false;
   }
- return redundantData;
+
 }
 
 
@@ -1205,16 +1205,14 @@ void IRAM_ATTR dscKeybusInterface::dscDataInterrupt() {
         static byte previousCmd1B[dscReadSize];
         case 0x05:  // Status: partitions 1-4
 		  if (redundantPanelData(previousCmd05, isrPanelData, isrPanelByteCount)){
-              /*
               if (skipFirst) {
                   skipData=false;
                   skipFirst=false;
               } else 
                   skipData=true;
           } else { // we skip the first cmd to remove spurious invalid ones during a changeover. Reported by on a pc5005
-          */
                skipData=true;
-               //skipFirst=true;
+               skipFirst=true;
            }
               /*
 			 if (!goodCmd && (millis() - cmdTime) > cmdWaitTime) {
@@ -1234,17 +1232,14 @@ void IRAM_ATTR dscKeybusInterface::dscDataInterrupt() {
 
         case 0x1B:  // Status: partitions 5-8
           if (redundantPanelData(previousCmd1B, isrPanelData, isrPanelByteCount)){
-              /*
               if (skipFirst) {
                   skipData=false;
                   skipFirst=false;
               } else 
                   skipData=true;
           } else {  // we skip the first cmd to remove spurious invalid ones during a changeover. Reported by on a pc5005
-          */
                skipData=true;
-               
-              // skipFirst=true;
+               skipFirst=true;
           }
            /*
 			 if (!goodCmd && (millis() - cmdTime) > cmdWaitTime) {

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -1205,14 +1205,16 @@ void IRAM_ATTR dscKeybusInterface::dscDataInterrupt() {
         static byte previousCmd1B[dscReadSize];
         case 0x05:  // Status: partitions 1-4
 		  if (redundantPanelData(previousCmd05, isrPanelData, isrPanelByteCount)){
+              /*
               if (skipFirst) {
                   skipData=false;
                   skipFirst=false;
               } else 
                   skipData=true;
           } else { // we skip the first cmd to remove spurious invalid ones during a changeover. Reported by on a pc5005
+          */
                skipData=true;
-               skipFirst=true;
+               //skipFirst=true;
            }
               /*
 			 if (!goodCmd && (millis() - cmdTime) > cmdWaitTime) {
@@ -1232,14 +1234,17 @@ void IRAM_ATTR dscKeybusInterface::dscDataInterrupt() {
 
         case 0x1B:  // Status: partitions 5-8
           if (redundantPanelData(previousCmd1B, isrPanelData, isrPanelByteCount)){
+              /*
               if (skipFirst) {
                   skipData=false;
                   skipFirst=false;
               } else 
                   skipData=true;
           } else {  // we skip the first cmd to remove spurious invalid ones during a changeover. Reported by on a pc5005
+          */
                skipData=true;
-               skipFirst=true;
+               
+              // skipFirst=true;
           }
            /*
 			 if (!goodCmd && (millis() - cmdTime) > cmdWaitTime) {

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -139,7 +139,7 @@ class dscKeybusInterface {
     byte openZones[dscZones], openZonesChanged[dscZones];    // Zone status is stored in an array using 1 bit per zone, up to 64 zones
     bool alarmZonesStatusChanged;
     byte alarmZones[dscZones], alarmZonesChanged[dscZones];  // Zone alarm status is stored in an array using 1 bit per zone, up to 64 zones
-    static unsigned long cmdWaitTime; // time to delay treating 05/1b command as valid in ms
+    static bool debounce05;
     void setZoneFault(byte zone,bool fault) ;
     void addEmulatedZone(byte address);
     void removeEmulatedZone(byte address);

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -179,7 +179,8 @@ class dscKeybusInterface {
     //static void dscDataInterrupt(dscKeybusInterface *dscPointer);
     // Deprecated
     bool handlePanel();               // Returns true if valid panel data is available.  Relabeled to loop()
-
+    static volatile byte currentCmd;
+    
   private:
     
     void processPanelStatus();
@@ -213,7 +214,6 @@ class dscKeybusInterface {
     void printPanel_0x16();
     void printPanel_0x1B();
     void printPanel_0x1C();
-    void printPanel_0x22();
     void printPanel_0x27();
     void printPanel_0x28();
     void printPanel_0x2D();
@@ -221,7 +221,6 @@ class dscKeybusInterface {
     void printPanel_0x34();
     void printPanel_0x39();    
     void printPanel_0x3E();
-    void printPanel_0x41();
     void printPanel_0x4C();
     void printPanel_0x58();
     void printPanel_0x5D();
@@ -265,15 +264,10 @@ class dscKeybusInterface {
     void printModule_0x77();
     void printModule_0xBB();
     void printModule_0xDD();
-    void printModule_Panel_Status();
     void printModule_Panel_0x11();
-    void printModule_Panel_0x41();
     void printModule_Panel_0xD5();
     void printModule_Notification();
     void printModule_Keys();
-    void printModule_KeyCodes(byte keyByte);
-    void printModule_Expander();
-    void printModule_ExpanderZoneState(byte zoneByte, byte zoneMask, byte zoneMaskShift);
     
     void removeModule(byte address);
     static void setPendingZoneUpdate();
@@ -282,9 +276,11 @@ class dscKeybusInterface {
     static void addRequestToQueue(byte slot);
     static void setSupervisorySlot(byte slot,bool set);
     static byte getPendingUpdate();
+    static void fillBuffer(byte* src,int len);
     static zoneMaskType getUpdateMask(byte address);
-
-    static volatile byte updateQueue[updateQueueSize];
+    static void prepareResponse(byte);
+   // static void setBuffer(const void* src,int len);
+    //static volatile byte updateQueue[updateQueueSize];
     static byte outIdx,inIdx;
     static byte moduleIdx; 
     static moduleType modules[maxModules];
@@ -332,7 +328,7 @@ class dscKeybusInterface {
     static volatile byte panelBuffer[dscBufferSize][dscReadSize];
     static volatile byte panelBufferBitCount[dscBufferSize], panelBufferByteCount[dscBufferSize];
     static volatile byte moduleBitCount, moduleByteCount;
-    static volatile byte currentCmd, statusCmd,moduleCmd,moduleSubCmd;
+    static volatile byte statusCmd,moduleCmd,moduleSubCmd;
     static volatile byte isrPanelData[dscReadSize], isrPanelBitTotal, isrPanelBitCount, isrPanelByteCount;
     static volatile byte isrModuleData[dscReadSize], isrModuleBitTotal, isrModuleBitCount, isrModuleByteCount;
 };

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -17,31 +17,29 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
  #include "dscKeybusInterface.h"
-
 
 /*
  *  printPanelMessage() checks the first byte of a message from the panel for
  *  known commands
  */
+
+
 void dscKeybusInterface::printPanelMessage() {
   switch (panelData[0]) {
     case 0x05: printPanel_0x05(); return;  // Panel status: partitions 1-4
     case 0x0A: printPanel_0x0A(); return;  // Panel status in alarm/programming, partitions 1-4
     case 0x11: printPanel_0x11(); return;  // Module supervision query
-    case 0x16: printPanel_0x16(); return;  // Panel configuration
+    case 0x16: printPanel_0x16(); return;  // Zone wiring
     case 0x1B: printPanel_0x1B(); return;  // Panel status: partitions 5-8
     case 0x1C: printPanel_0x1C(); return;  // Verify keypad Fire/Auxiliary/Panic
-    case 0x22: printPanel_0x22(); return;  // Zone expander slot 8 query
     case 0x27: printPanel_0x27(); return;  // Panel status and zones 1-8 status
-    case 0x28: printPanel_0x28(); return;  // Zone expander slot 9 query
+    case 0x28: printPanel_0x28(); return;  // Zone expander zones 9-16 query
     case 0x2D: printPanel_0x2D(); return;  // Panel status and zones 9-16 status
-    case 0x33: printPanel_0x33(); return;  // Zone expander slot 10 query
+    case 0x33: printPanel_0x33(); return;  // Zone expander zones 17-24 query
     case 0x34: printPanel_0x34(); return;  // Panel status and zones 17-24 status
-    case 0x39: printPanel_0x39(); return;  // Zone expander slot 11 query
+    case 0x39: printPanel_0x39(); return;  // Zone expander zones 25-32 query
     case 0x3E: printPanel_0x3E(); return;  // Panel status and zones 25-32 status
-    case 0x41: printPanel_0x41(); return;  // Wireless module query
     case 0x4C: printPanel_0x4C(); return;  // Unknown Keybus query
     case 0x58: printPanel_0x58(); return;  // Unknown Keybus query
     case 0x5D: printPanel_0x5D(); return;  // Flash panel lights: status and zones 1-32, partition 1
@@ -59,7 +57,7 @@ void dscKeybusInterface::printPanelMessage() {
     case 0xB1: printPanel_0xB1(); return;  // Enabled zones 1-32
     case 0xBB: printPanel_0xBB(); return;  // Bell
     case 0xC3: printPanel_0xC3(); return;  // Keypad status
-    case 0xCE: printPanel_0xCE(); return;  // Panel status
+    case 0xCE: printPanel_0xCE(); return;  // Unknown command
     case 0xD5: printPanel_0xD5(); return;  // Keypad zone query
     case 0xE6: printPanel_0xE6(); return;  // Extended status commands: partitions 3-8, zones 33-64
     case 0xEB: printPanel_0xEB(); return;  // Date, time, system status messages - partitions 1-8
@@ -83,29 +81,25 @@ void dscKeybusInterface::printModuleMessage() {
     case 0xDD: printModule_0xDD(); return;  // Keypad panic alarm
   }
 
-  // Processes keypad and module notifications and responses to panel queries
-  stream->print(F("[Module/0x"));
-  if (currentCmd < 16) stream->print("0");
-  stream->print(currentCmd, HEX);
-  stream->print(F("] "));
-
+  // Module responses to panel queries
   switch (currentCmd) {
-    case 0x05:
-    case 0x1B: printModule_Panel_Status(); return;   // Module notifications sent during panel status commands
-    case 0x11: printModule_Panel_0x11(); return;     // Module supervision query response
-    case 0x41: printModule_Panel_0x41(); return;     // Wireless module query response
-    case 0xD5: printModule_Panel_0xD5(); return;     // Keypad zone query response
-    case 0x22:
-    case 0x28:
-    case 0x33:
-    case 0x39: printModule_Expander(); return;      // Zone expander slots 9-11 response
-    default: stream->print(F("Unknown data"));
+    case 0x11: printModule_Panel_0x11(); return;  // Module supervision query response
+    case 0xD5: printModule_Panel_0xD5(); return;  // Keypad zone query response
   }
+
+  // Keypad and module status update notifications
+  if (moduleData[4] != 0xFF || moduleData[5] != 0xFF) {
+    printModule_Notification();
+    return;
+  }
+
+  // Keypad keys
+  printModule_Keys();
 }
 
 
 /*
- *  Prints panel messages
+ *  Print panel messages
  */
 
 
@@ -268,7 +262,7 @@ void dscKeybusInterface::printPanelStatus0(byte panelByte) {
     case 0xE5: stream->print(F("Auto-arm cancelled")); break;
     case 0xE6: stream->print(F("Disarmed special: keyswitch/wireless key/DLS")); break;
     case 0xE7: stream->print(F("Panel battery trouble")); break;
-    case 0xE8: stream->print(F("Panel AC power trouble")); break;
+    case 0xE8: stream->print(F("Panel AC power failure")); break;
     case 0xE9: stream->print(F("Bell trouble")); break;
     case 0xEA: stream->print(F("Power on +16s")); break;
     case 0xEC: stream->print(F("Telephone line trouble")); break;
@@ -780,16 +774,12 @@ void dscKeybusInterface::printPanel_0x11() {
 
 
 /*
- *  0x16: Panel configuration
+ *  0x16: Zone wiring
  *  Interval: 4min
  *  CRC: yes
- *  Byte 2: Unknown, identical with all tested panels
- *  Byte 3: Panel version
- *  Byte 4 bits 0,1: Zone wiring resistors configuration
- *  Byte 4 bit 2: Unknown
- *  Byte 4 bit 3: Code length flag
- *  Byte 4 bit 4: *8 programming mode flag (?), possible signal to disable other keypads while programming
- *  Byte 4 bits 5-7: Unknown
+ *  Byte 2: TBD, identical with PC1555MX, PC5015, PC1832
+ *  Byte 3: TBD, different between PC1555MX, PC5015, PC1832
+ *  Byte 4 bits 2-7: TBD, identical with PC1555MX and PC5015
  *
  *  00010110 0 00001110 00100011 11010001 00011001 [0x16] PC1555MX | Zone wiring: NC | Exit *8 programming
  *  00010110 0 00001110 00100011 11010010 00011001 [0x16] PC1555MX | Zone wiring: EOL | Exit *8 programming
@@ -810,33 +800,36 @@ void dscKeybusInterface::printPanel_0x16() {
   }
 
   if (panelData[2] == 0x0E) {
-
-    // Panel version
-    stream->print(F("Panel version: v"));
-    stream->print(panelData[3] >> 4);
-    stream->print(F("."));
-    stream->print(panelData[3] & 0x0F);
-
-    // Zone wiring
-    stream->print(F(" | Zone wiring: "));
+      
+    stream->print(F("Panel version: "));
+    stream->print(panelData[3],HEX);
+/*
+    switch (panelData[3]) {
+      case 0x10: stream->print(F("PC5015 ")); break;
+      case 0x11: stream->print(F("PC5016 ")); break;
+      case 0x22: stream->print(F("PC1565 ")); break;
+      case 0x23: stream->print(F("PC1555MX ")); break;
+      case 0x41: stream->print(F("PC1832 ")); break;
+      case 0x42: stream->print(F("PC1864 ")); break;
+      default: stream->print(F("Unknown panel ")); break;
+    }
+*/
     switch (panelData[4] & 0x03) {
-      case 0x01: stream->print(F("NC ")); break;
-      case 0x02: stream->print(F("EOL ")); break;
-      case 0x03: stream->print(F("DEOL ")); break;
+      case 0x01: stream->print(F("| Zone wiring: NC ")); break;
+      case 0x02: stream->print(F("| Zone wiring: EOL ")); break;
+      case 0x03: stream->print(F("| Zone wiring: DEOL ")); break;
     }
 
-    // Code length
-    stream->print(F("| Code length: "));
-    if (panelData[4] & 0x08) stream->print(F("6"));
-    else stream->print(F("4"));
-    stream->print(F(" digits "));
-
-    // *8 programming mode status
-    stream->print(F("| *8 programming: "));
-    if (panelData[4] & 0x10) stream->print(F("no "));
-    else stream->print(F("yes "));
+    switch (panelData[4] >> 2) {
+      case 0x2C: stream->print(F("| Armed")); break;
+      case 0x2D: stream->print(F("| Interval 4m")); break;
+      case 0x34: stream->print(F("| Exit installer programming")); break;
+      case 0x39: stream->print(F("| Installer programming")); break;
+      case 0x3C: stream->print(F("| Armed, Exit *8 +15s, Power-on +2m")); break;
+      case 0x3D: stream->print(F("| Interval 4m")); break;
+      default: stream->print(F("| Unknown data")); break;
+    }
   }
-
   else stream->print(F("Unknown data"));
 }
 
@@ -915,20 +908,6 @@ void dscKeybusInterface::printPanel_0x1C() {
 
 
 /*
- *  0x22: Zone expander slot 8 query
- *  Interval: after zone expander status notification
- *  CRC: no
- *
- *  11111111 1 11111111 11111111 01111111 11111111 11111111 11111111 11111111 11111111 [Module/0x05] Zone expander notification: Slot 8
- *  00100010 0 11111111 11111111 11111111 11111111 11111111 [0x22] Zone expander slot 8 query
- *  11111111 1 01011001 01010101 01010101 01010101 10000100 [Module/0x22] Zone expander status update: Slot 8 | Zones changed: 2 tamper
- */
-void dscKeybusInterface::printPanel_0x22() {
-  stream->print(F("Zone expander slot 8 query"));
-}
-
-
-/*
  *  0x27: Status with zones 1-8
  *  Interval: 4m
  *  CRC: yes
@@ -985,7 +964,7 @@ void dscKeybusInterface::printPanel_0x27() {
 
 
 /*
- *  0x28: Zone expander slot 9 query
+ *  0x28: Zone expander zones 9-16 query
  *  Interval: after zone expander status notification
  *  CRC: no
  *
@@ -994,7 +973,7 @@ void dscKeybusInterface::printPanel_0x27() {
  *  11111111 1 01010111 01010101 11111111 11111111 01101111 [Zone Expander] Status
  */
 void dscKeybusInterface::printPanel_0x28() {
-  stream->print(F("Zone expander slot 9 query"));
+  stream->print(F("Zone expander zones 9-16 query"));
 }
 
 
@@ -1041,7 +1020,7 @@ void dscKeybusInterface::printPanel_0x2D() {
 
 
 /*
- *  0x33: Zone expander slot 10 query
+ *  0x33: Zone expander zones 17-24 query
  *  Interval:
  *  CRC:
  *
@@ -1050,7 +1029,7 @@ void dscKeybusInterface::printPanel_0x2D() {
  *  11111111 1 01010111 01010101 11111111 11111111 01101111 [Zone Expander] Status
  */
 void dscKeybusInterface::printPanel_0x33() {
-  stream->print(F("Zone expander slot 10 query"));
+  stream->print(F("Zone expander zones 17-24 query"));
 }
 
 
@@ -1094,7 +1073,7 @@ void dscKeybusInterface::printPanel_0x34() {
 
 
 /*
- *  0x39: Zone expander slot 11 query
+ *  0x39: Zone expander zones 25-32 query
  *  Interval:
  *  CRC:
  *
@@ -1103,7 +1082,7 @@ void dscKeybusInterface::printPanel_0x34() {
  *  11111111 1 01010111 01010101 11111111 11111111 01101111 [Zone Expander] Status
  */
 void dscKeybusInterface::printPanel_0x39() {
-  stream->print(F("Zone expander slot 11 query"));
+  stream->print(F("Zone expander zones 25-32 query"));
 }
 
 
@@ -1143,18 +1122,6 @@ void dscKeybusInterface::printPanel_0x3E() {
   else {
     printPanelBitNumbers(6,25);
   }
-}
-
-
-/*
- *  0x41: Wireless module query
- *  Interval: immediate on wireless module notification
- *  CRC: no
- *
- *  01000001 0 11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111 [0x41] Wireless module query
- */
-void dscKeybusInterface::printPanel_0x41() {
-  stream->print(F("Wireless module query"));
 }
 
 
@@ -1661,7 +1628,7 @@ void dscKeybusInterface::printPanel_0xC3() {
 
 
 /*
- *  0xCE: Panel status
+ *  0xCE: Unknown command
  *  CRC: yes
  *
  * 11001110 0 00000001 10100000 00000000 00000000 00000000 01101111 [0xCE]  // Partition 1 exit delay
@@ -1678,20 +1645,19 @@ void dscKeybusInterface::printPanel_0xCE() {
     return;
   }
 
-  if (panelData[3] & 0x20) {
-    switch (panelData[3] & 0x03) {
-      case 0x00: printPanelStatus0(4); return;
-      case 0x01: printPanelStatus1(4); return;
-      case 0x02: printPanelStatus2(4); return;
-      case 0x03: printPanelStatus3(4); return;
+  switch (panelData[2]) {
+    case 0x01: {
+      switch (panelData[3]) {
+        case 0xA0: stream->print(F("Partition 1,2 exit delay, partition 1,2 disarmed")); break;
+        case 0xA4: stream->print(F("Partition 2 armed away")); break;
+        case 0xB1: stream->print(F("Partition 1 armed stay")); break;
+        case 0xB3: stream->print(F("Partition 1 armed away")); break;
+        default: stream->print(F("Unknown data")); break;
+      }
+      break;
     }
-  }
-  else {
-    stream->print(F("Unknown data"));
-    stream->print(F(" [Byte 2/0x"));
-    if (panelData[2] < 16) stream->print("0");
-    stream->print(panelData[2], HEX);
-    stream->print(F("] "));
+    case 0x40: stream->print(F("Unknown data")); break;
+    default: stream->print(F("Unknown data")); break;
   }
 }
 
@@ -1722,13 +1688,13 @@ void dscKeybusInterface::printPanel_0xE6() {
 
   switch (panelData[2]) {
     case 0x03: printPanel_0xE6_0x03(); break;  // Status in alarm/programming, partitions 5-8
-    case 0x08: printPanel_0xE6_0x08(); break;  // Zone expander zones slot 12 query
+  //  case 0x08: printPanel_0xE6_0x08(); break;  // Zone expander zones 33-40 query
     case 0x09: printPanel_0xE6_0x09(); break;  // Zones 33-40 status
-    case 0x0A: printPanel_0xE6_0x0A(); break;  // Zone expander zones slot 13 query
+  //  case 0x0A: printPanel_0xE6_0x0A(); break;  // Zone expander zones 41-48 query
     case 0x0B: printPanel_0xE6_0x0B(); break;  // Zones 41-48 status
-    case 0x0C: printPanel_0xE6_0x0C(); break;  // Zone expander zones slot 14 query
+   // case 0x0C: printPanel_0xE6_0x0C(); break;  // Zone expander zones 49-56 query
     case 0x0D: printPanel_0xE6_0x0D(); break;  // Zones 49-56 status
-    case 0x0E: printPanel_0xE6_0x0E(); break;  // Zone expander zones slot 16 query
+   // case 0x0E: printPanel_0xE6_0x0E(); break;  // Zone expander zones 57-64 query
     case 0x0F: printPanel_0xE6_0x0F(); break;  // Zones 57-64 status
     case 0x17: printPanel_0xE6_0x17(); break;  // Flash panel lights: status and zones 1-32, partitions 1-8
     case 0x18: printPanel_0xE6_0x18(); break;  // Flash panel lights: status and zones 33-64, partitions 1-8
@@ -1755,10 +1721,10 @@ void dscKeybusInterface::printPanel_0xE6_0x03() {
 
 
 /*
- *  0xE6_0x08: Zone expander slot 12 query
+ *  0xE6_0x08: Zone expander zones 33-40 query
  */
 void dscKeybusInterface::printPanel_0xE6_0x08() {
-  stream->print(F("Zone expander slot 12 query"));
+  stream->print(F("Zone expander zones 33-40 query"));
 }
 
 
@@ -1775,10 +1741,10 @@ void dscKeybusInterface::printPanel_0xE6_0x09() {
 
 
 /*
- *  0xE6_0x0A: Zone expander slot 13 query
+ *  0xE6_0x0A: Zone expander zones 41-48 query
  */
 void dscKeybusInterface::printPanel_0xE6_0x0A() {
-  stream->print(F("Zone expander slot 13 query"));
+  stream->print(F("Zone expander zones 41-48 query"));
 }
 
 
@@ -1795,10 +1761,10 @@ void dscKeybusInterface::printPanel_0xE6_0x0B() {
 
 
 /*
- *  0xE6_0x0C: Zone expander slot 14 query
+ *  0xE6_0x0C: Zone expander zones 49-56 query
  */
 void dscKeybusInterface::printPanel_0xE6_0x0C() {
-  stream->print(F("Zone expander slot 14 query"));
+  stream->print(F("Zone expander zones 49-56 query"));
 }
 
 
@@ -1815,10 +1781,10 @@ void dscKeybusInterface::printPanel_0xE6_0x0D() {
 
 
 /*
- *  0xE6_0x0E: Zone expander slot 16 query
+ *  0xE6_0x0E: Zone expander zones 57-64 query
  */
 void dscKeybusInterface::printPanel_0xE6_0x0E() {
-  stream->print(F("Zone expander slot 16 query"));
+  stream->print(F("Zone expander zones 57-64 query"));
 }
 
 
@@ -1940,30 +1906,8 @@ void dscKeybusInterface::printPanel_0xE6_0x19() {
     01110101 0 00000000 01110101 [0x75] Partition 1 | Tone: off
  */
 void dscKeybusInterface::printPanel_0xE6_0x1A() {
-  bool printSeparator = false;
-
-  if (panelData[6] & 0x08) {
-    printSeparator = true;
-    stream->print(F("Loss of system time "));
-  }
-
-  if (panelData[6] & 0x10) {
-    if (printSeparator) stream->print(F("| "));
-    printSeparator = true;
-    stream->print(F("AC power trouble "));
-  }
-
-  if (panelData[6] & 0x40) {
-    if (printSeparator) stream->print(F("| "));
-    printSeparator = true;
-    stream->print(F("Fail to communicate "));
-  }
-
-  if (panelData[6] & 0x80) {
-    if (printSeparator) stream->print(F("| "));
-    printSeparator = true;
-    stream->print(F("Bell on (?) "));
-  }
+  stream->print(F("0x1A: "));
+  stream->print(F("Unknown data"));
 }
 
 
@@ -2203,58 +2147,33 @@ void dscKeybusInterface::printModule_0xDD() {
 
 
 /*
- *  Module status notifications
+ *  Keybus status notifications
  */
 
+void dscKeybusInterface::printModule_Notification() {
+  switch (moduleData[4]) {
+    // Zone expander: status update notification, panel responds with 0x28
+    // 11111111 1 11111111 11111111 10111111 11111111 [Zone Expander] Status notification
+    // 00101000 0 11111111 11111111 11111111 11111111 11111111 [0x28] Zone expander query
+    case 0xBF:
+      stream->print(F("[Zone Expander] Status notification"));
+      break;
 
-// Processes module data sent during panel status commands 0x05, 0x1B
-void dscKeybusInterface::printModule_Panel_Status() {
-  printModule_Keys();
-
-  bool printSeparator = false;
-  if ((moduleData[4] & 0xF0) != 0xF0 || (moduleByteCount > 6 && (moduleData[7] & 0xF0) != 0xF0)) {
-    printSeparator = true;
-    stream->print(F("Zone expander notification: Slot "));
-    if ((moduleData[4] & 0x80) == 0) stream->print(F("8 "));
-    if ((moduleData[4] & 0x40) == 0) stream->print(F("9 "));
-    if ((moduleData[4] & 0x20) == 0) stream->print(F("10 "));
-    if ((moduleData[4] & 0x10) == 0) stream->print(F("11 "));
-    if (moduleByteCount > 6) {
-      if ((moduleData[7] & 0x80) == 0) stream->print(F("12 "));
-      if ((moduleData[7] & 0x40) == 0) stream->print(F("13 "));
-      if ((moduleData[7] & 0x20) == 0) stream->print(F("14 "));
-      if ((moduleData[7] & 0x10) == 0) stream->print(F("16 "));
-    }
+    // Keypad: Unknown Keybus notification, panel responds with 0x4C query
+    // 11111111 1 11111111 11111111 11111110 11111111 [Keypad] Unknown Keybus notification
+    // 01001100 0 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 [0x4C] Unknown Keybus query
+    case 0xFE:
+      stream->print(F("[Keypad] Unknown Keybus notification"));
+      break;
   }
 
-  // Module notifications
-  // 11111111 1 11111111 11111111 10111111 11111111 [Module/0x05] Zone expander notification: Slot 9
-  // 11111111 1 11111111 11111111 11011111 11111111 [Module/0x05] Zone expander notification: Slot 10
-  // 11111111 1 11111111 11111111 11101111 11111111 [Module/0x05] Zone expander notification: Slot 11
-
-  // 11111111 1 11111111 11111111 11110111 11111111 [Module/0x05] Wireless module battery notification
-  if ((moduleData[4] & 0x08) == 0) {
-    if (printSeparator) stream->print(F("| "));
-    printSeparator = true;
-    stream->print(F("Wireless module battery notification"));
-  }
-
-  // Unknown module notification, panel responds with 0x4C query
-  // 11111111 1 11111111 11111111 11111110 11111111 [Keypad] Unknown Keybus notification
-  // 01001100 0 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 [0x4C] Unknown Keybus query
-  if ((moduleData[4] & 0x01) == 0) {
-    if (printSeparator) stream->print(F("| "));
-    printSeparator = true;
-    stream->print(F("Unknown module notification"));
-  }
-
-  // Keypad zone status update notification, panel responds with 0xD5 query
-  // 11111111 1 11111111 11111111 11111111 11111011 [Keypad] Zone status notification
-  // 11010101 0 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 [0xD5] Keypad zone query
-  if ((moduleData[5] & 0x04) == 0) {
-    if (printSeparator) stream->print(F("| "));
-    printSeparator = true;
-    stream->print(F("Keypad zone status notification"));
+  switch (moduleData[5]) {
+    // Keypad: zone status update notification, panel responds with 0xD5 query
+    // 11111111 1 11111111 11111111 11111111 11111011 [Keypad] Zone status notification
+    // 11010101 0 10101010 10101010 10101010 10101010 10101010 10101010 10101010 10101010 [0xD5] Keypad zone query
+    case 0xFB:
+      stream->print(F("[Keypad] Zone status notification"));
+      break;
   }
 }
 
@@ -2267,7 +2186,7 @@ void dscKeybusInterface::printModule_Panel_Status() {
  */
 void dscKeybusInterface::printModule_Panel_0x11() {
   if (moduleData[2] != 0xFF || moduleData[3] != 0xFF) {
-    stream->print(F("Keypad slots: "));
+    stream->print(F("[Keypad] Slots: "));
     if ((moduleData[2] & 0xC0) == 0) stream->print(F("1 "));
     if ((moduleData[2] & 0x30) == 0) stream->print(F("2 "));
     if ((moduleData[2] & 0x0C) == 0) stream->print(F("3 "));
@@ -2278,60 +2197,20 @@ void dscKeybusInterface::printModule_Panel_0x11() {
     if ((moduleData[3] & 0x03) == 0) stream->print(F("8 "));
   }
 
-  if (moduleData[4] != 0xFF || (moduleData[5] != 0xFF && moduleData[5] != 0xF3) || ((moduleByteCount > 7) && (moduleData[7] != 0xFF))) {
-    stream->print(F("| Zone expander slots: "));
-    if (moduleByteCount > 7) {
-      if ((moduleData[4] & 0xC0) == 0) stream->print(F("9 "));
-      if ((moduleData[4] & 0x30) == 0) stream->print(F("10 "));
-      if ((moduleData[4] & 0x0C) == 0) stream->print(F("11 "));
-      if ((moduleData[4] & 0x03) == 0) stream->print(F("12 "));
-      if ((moduleData[5] & 0xC0) == 0) stream->print(F("13 "));
-      if ((moduleData[5] & 0x30) == 0) stream->print(F("14 "));
-      if ((moduleData[7] & 0x03) == 0) stream->print(F("16 "));
-    }
-    else {
-      if ((moduleData[4] & 0xF0) == 0) stream->print(F("9 "));
-      if ((moduleData[4] & 0x0F) == 0) stream->print(F("10 "));
-      if ((moduleData[5] & 0xF0) == 0) stream->print(F("11 "));
-    }
-  }
-}
-
-
-/*  Wireless module query response to panel query 0x41
- *
- *  01000001 0 11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111 [0x41] Wireless module query
- *  11111111 1 11111111 11011111 11111111 11111111 11111111 11111111 11111111 11111111 11011000 [Module/0x41] Wireless module | Battery low zones: 11
- *  11111111 1 11111111 11111111 11111111 11111111 11111111 11011111 11111111 11111111 11011000 [Module/0x41] Wireless module | Battery restored zones: 11
- */
-void dscKeybusInterface::printModule_Panel_0x41() {
-  stream->print(F("Wireless module "));
-  if (moduleData[3] != 0xFF || moduleData[4] != 0xFF || moduleData[5] != 0xFF) {
-    stream->print(F("| Battery low zones: "));
-    byte batteryZone = 9;
-    for (byte moduleByte = 3; moduleByte < 6; moduleByte++) {
-        for (byte zoneMask = 0x80; zoneMask != 0; zoneMask >>= 1) {
-          if ((moduleData[moduleByte] & zoneMask) == 0) stream->print(batteryZone);
-          batteryZone++;
-        }
-    }
-  }
-
-  if (moduleData[7] != 0xFF || moduleData[8] != 0xFF || moduleData[9] != 0xFF) {
-    stream->print(F("| Battery restored zones: "));
-    byte batteryZone = 9;
-    for (byte moduleByte = 7; moduleByte < 10; moduleByte++) {
-        for (byte zoneMask = 0x80; zoneMask != 0; zoneMask >>= 1) {
-          if ((moduleData[moduleByte] & zoneMask) == 0) stream->print(batteryZone);
-          batteryZone++;
-        }
-    }
+  if (moduleData[4] != 0xFF || (moduleData[5] != 0xFF && moduleData[5] != 0xF3)) {
+    stream->print(F(" [Zone Expander] Modules: "));
+    if ((moduleData[4] & 0xC0) == 0) stream->print(F("1 "));
+    if ((moduleData[4] & 0x30) == 0) stream->print(F("2 "));
+    if ((moduleData[4] & 0x0C) == 0) stream->print(F("3 "));
+    if ((moduleData[4] & 0x03) == 0) stream->print(F("4 "));
+    if ((moduleData[5] & 0xC0) == 0) stream->print(F("5 "));
+    if ((moduleData[5] & 0x30) == 0) stream->print(F("6 "));
   }
 }
 
 
 /*
- *  Keypad zone query response to panel query 0xD5
+ *  Keypad: Panel 0xD5 zone query response
  *  Bytes 2-9: Keypad slots 1-8
  *  Bits 2,3: TBD
  *  Bits 6,7: TBD
@@ -2366,59 +2245,57 @@ void dscKeybusInterface::printModule_Panel_0xD5() {
 
 
 /*
- *  Keypads keys
+ *  Keypad: keys
  *
- *  11111111 1 00000101 11111111 11111111 11111111 [Module/0x05] Partition 1 Key: 1
- *  11111111 1 00101101 11111111 11111111 11111111 [Module/0x05] Partition 1 Key: #
+ *  11111111 1 00000101 11111111 11111111 11111111 [Keypad] 1
+ *  11111111 1 00101101 11111111 11111111 11111111 [Keypad] #
  */
 void dscKeybusInterface::printModule_Keys() {
+  stream->print(F("[Keypad] "));
 
-  if (hideKeypadDigits && (moduleData[2] <= 0x27 || moduleData[3] <= 0x27 || (moduleByteCount > 6 && (moduleData[8] <= 0x27 || moduleData[9] <= 0x27)))) {
-    stream->print(F("[Digit]"));
-    return;
-  }
-
+  byte keyByte = 2;
   if (currentCmd == 0x05) {
     if (moduleData[2] != 0xFF) {
-      stream->print(F("Partition 1 Key: "));
-      printModule_KeyCodes(2);
+      stream->print(F("Partition 1 | Key: "));
     }
     else if (moduleData[3] != 0xFF) {
-      stream->print(F("Partition 2 Key: "));
-      printModule_KeyCodes(3);
+      stream->print(F("Partition 2 | Key: "));
+      keyByte = 3;
     }
-    else if (moduleByteCount > 6 && moduleData[8] != 0xFF) {
-      stream->print(F("Partition 3 Key: "));
-      printModule_KeyCodes(8);
+    else if (moduleData[8] != 0xFF) {
+      stream->print(F("Partition 3 | Key: "));
+      keyByte = 8;
     }
 
-    else if (moduleByteCount > 6 && moduleData[9] != 0xFF) {
-      stream->print(F("Partition 4 Key: "));
-      printModule_KeyCodes(9);
+    else if (moduleData[9] != 0xFF) {
+      stream->print(F("Partition 4 | Key: "));
+      keyByte = 9;
     }
   }
   else if (currentCmd == 0x1B) {
     if (moduleData[2] != 0xFF) {
-      stream->print(F("Partition 5 Key: "));
-      printModule_KeyCodes(2);
+      stream->print(F("Partition 5 | Key: "));
     }
     else if (moduleData[3] != 0xFF) {
-      stream->print(F("Partition 6 Key: "));
-      printModule_KeyCodes(3);
+      stream->print(F("Partition 6 | Key: "));
+      keyByte = 3;
     }
     else if (moduleData[8] != 0xFF) {
-      stream->print(F("Partition 7 Key: "));
-      printModule_KeyCodes(8);
+      stream->print(F("Partition 7 | Key: "));
+      keyByte = 8;
     }
 
     else if (moduleData[9] != 0xFF) {
-      stream->print(F("Partition 8 Key: "));
-      printModule_KeyCodes(9);
+      stream->print(F("Partition 8 | Key: "));
+      keyByte = 9;
     }
   }
-}
 
-void dscKeybusInterface::printModule_KeyCodes(byte keyByte) {
+  if (hideKeypadDigits && (moduleData[2] <= 0x27 || moduleData[3] <= 0x27 || moduleData[8] <= 0x27 || moduleData[9] <= 0x27)) {
+    stream->print(F("[Digit]"));
+    return;
+  }
+
   switch (moduleData[keyByte]) {
     case 0x00: stream->print(F("0")); break;
     case 0x05: stream->print(F("1")); break;
@@ -2452,111 +2329,10 @@ void dscKeybusInterface::printModule_KeyCodes(byte keyByte) {
     case 0xEB: stream->print(F("Function key [20] Future Use")); break;
     case 0xEC: stream->print(F("Command output 4")); break;
     case 0xF7: stream->print(F("Left/right arrow")); break;
-  }
-}
-
-
-void dscKeybusInterface::printModule_Expander() {
-  stream->print(F("Zone expander status update: Slot "));
-  switch (currentCmd) {
-    case 0x22: stream->print(F("8 ")); break;
-    case 0x28: stream->print(F("9 ")); break;
-    case 0x33: stream->print(F("10 ")); break;
-    case 0x39: stream->print(F("11 ")); break;
-  }
-
-  if (moduleData[2] != moduleData[3] || moduleData[4] != moduleData[5]) {
-    stream->print(F("| Zones changed: "));
-
-    if ((moduleData[2] & 0x03) != (moduleData[3] & 0x03)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("1 ")); break;
-        case 0x28: stream->print(F("9 ")); break;
-        case 0x33: stream->print(F("17 ")); break;
-        case 0x39: stream->print(F("25 ")); break;
-      }
-      printModule_ExpanderZoneState(2, 0x03, 0);
-    }
-
-    if ((moduleData[2] & 0x0C) != (moduleData[3] & 0x0C)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("2 ")); break;
-        case 0x28: stream->print(F("10 ")); break;
-        case 0x33: stream->print(F("18 ")); break;
-        case 0x39: stream->print(F("26 ")); break;
-      }
-      printModule_ExpanderZoneState(2, 0x0C, 2);
-    }
-
-    if ((moduleData[2] & 0x30) != (moduleData[3] & 0x30)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("3 ")); break;
-        case 0x28: stream->print(F("11 ")); break;
-        case 0x33: stream->print(F("19 ")); break;
-        case 0x39: stream->print(F("27 ")); break;
-      }
-      printModule_ExpanderZoneState(2, 0x30, 4);
-    }
-
-    if ((moduleData[2] & 0xC0) != (moduleData[3] & 0xC0)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("4 ")); break;
-        case 0x28: stream->print(F("12 ")); break;
-        case 0x33: stream->print(F("20 ")); break;
-        case 0x39: stream->print(F("28 ")); break;
-      }
-      printModule_ExpanderZoneState(2, 0xC0, 6);
-    }
-
-    if ((moduleData[4] & 0x03) != (moduleData[5] & 0x03)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("5 ")); break;
-        case 0x28: stream->print(F("13 ")); break;
-        case 0x33: stream->print(F("21 ")); break;
-        case 0x39: stream->print(F("29 ")); break;
-      }
-      printModule_ExpanderZoneState(4, 0x03, 0);
-    }
-
-    if ((moduleData[4] & 0x0C) != (moduleData[5] & 0x0C)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("6 ")); break;
-        case 0x28: stream->print(F("14 ")); break;
-        case 0x33: stream->print(F("22 ")); break;
-        case 0x39: stream->print(F("30 ")); break;
-      }
-      printModule_ExpanderZoneState(4, 0x0C, 2);
-    }
-
-    if ((moduleData[4] & 0x30) != (moduleData[5] & 0x30)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("7 ")); break;
-        case 0x28: stream->print(F("15 ")); break;
-        case 0x33: stream->print(F("23 ")); break;
-        case 0x39: stream->print(F("31 ")); break;
-      }
-      printModule_ExpanderZoneState(4, 0x30, 4);
-    }
-
-    if ((moduleData[4] & 0xC0) != (moduleData[5] & 0xC0)) {
-      switch (currentCmd) {
-        case 0x22: stream->print(F("8 ")); break;
-        case 0x28: stream->print(F("16 ")); break;
-        case 0x33: stream->print(F("24 ")); break;
-        case 0x39: stream->print(F("32 ")); break;
-      }
-      printModule_ExpanderZoneState(4, 0xC0, 6);
-    }
-  }
-}
-
-
-void dscKeybusInterface::printModule_ExpanderZoneState(byte zoneByte, byte zoneMask, byte zoneMaskShift) {
-  switch ((moduleData[zoneByte] & zoneMask) >> zoneMaskShift) {
-    case 0: stream->print(F("open ")); break;
-    case 1: stream->print(F("closed ")); break;
-    case 2: stream->print(F("tamper ")); break;
-    case 3: stream->print(F("EOL open ")); break;
+    default:
+      stream->print(F("Unknown key: 0x"));
+      stream->print(moduleData[keyByte], HEX);
+      break;
   }
 }
 


### PR DESCRIPTION
This PR introduces some changes to the expander code to reduce the amount of ram used in the ISR routines.  This became an issue with the ESPHome application which used a larger amount of IRAM in the latest updates. 
Also added were corrections to fix issues introduced in the 05/1b cmd handling discovered in the unlocker sketch.