### PR TITLE
Support for 95 users, decoded more status & keys messages, additions to 0x87, 0xC3 cmds

### DIFF
--- a/examples/esp32/VirtualKeypad-Blynk/VirtualKeypad-Blynk.ino
+++ b/examples/esp32/VirtualKeypad-Blynk/VirtualKeypad-Blynk.ino
@@ -772,14 +772,18 @@ void setStatus(byte partition) {
     case 0x0B: lcd.print(0,1, "                "); lcd.print(0,1, "Quick exit"); break;
     case 0x0C: lcd.print(0,1, "                "); lcd.print(0,1, "Entry delay"); break;
     case 0x0D: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm memory"); break;
+    case 0x0E: lcd.print(0,1, "                "); lcd.print(0,1, "Not available"); break;    
     case 0x10: lcd.print(0,1, "                "); lcd.print(0,1, "Keypad lockout"); break;
     case 0x11: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm"); break;
+    case 0x12: lcd.print(0,1, "                "); lcd.print(0,1, "Battery check"); break;    
     case 0x14: lcd.print(0,1, "                "); lcd.print(0,1, "Auto-arm"); break;
     case 0x15: lcd.print(0,1, "                "); lcd.print(0,1, "Arm with bypass"); break;
     case 0x16: lcd.print(0,1, "                "); lcd.print(0,1, "No entry delay"); break;
-    case 0x22: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm memory"); break;
+    case 0x19: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm occured"); break;    
+    case 0x22: lcd.print(0,1, "                "); lcd.print(0,1, "Recent closing"); break;
+    case 0x2F: lcd.print(0,1, "                "); lcd.print(0,1, "LCD Pixel check"); break;
     case 0x33: lcd.print(0,1, "                "); lcd.print(0,1, "Busy"); break;
-    case 0x3D: lcd.print(0,1, "                "); lcd.print(0,1, "Disarmed"); break;
+    case 0x3D: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm occured"); break;
     case 0x3E: lcd.print(0,1, "                "); lcd.print(0,1, "Disarmed"); break;
     case 0x40: lcd.print(0,1, "                "); lcd.print(0,1, "Keypad blanked"); break;
     case 0x8A: lcd.print(0,1, "                "); lcd.print(0,1, "Activate zones"); break;
@@ -795,7 +799,7 @@ void setStatus(byte partition) {
     case 0xA4: lcd.print(0,1, "                "); lcd.print(0,1, "Door chime off"); break;
     case 0xA5: lcd.print(0,1, "                "); lcd.print(0,1, "Master code"); break;
     case 0xA6: lcd.print(0,1, "                "); lcd.print(0,1, "Access codes"); break;
-    case 0xA7: lcd.print(0,1, "                "); lcd.print(0,1, "Enter new code"); break;
+    case 0xA7: lcd.print(0,1, "                "); lcd.print(0,1, "New 4-digit code"); break;
     case 0xA9: lcd.print(0,1, "                "); lcd.print(0,1, "User function"); break;
     case 0xAA: lcd.print(0,1, "                "); lcd.print(0,1, "Time and Date"); break;
     case 0xAB: lcd.print(0,1, "                "); lcd.print(0,1, "Auto-arm time"); break;
@@ -808,8 +812,10 @@ void setStatus(byte partition) {
     case 0xB8: lcd.print(0,1, "                "); lcd.print(0,1, "Enter * code"); break;
     case 0xB9: lcd.print(0,1, "                "); lcd.print(0,1, "Zone tamper"); break;
     case 0xBA: lcd.print(0,1, "                "); lcd.print(0,1, "Zones low batt."); break;
+    case 0xBC: lcd.print(0,1, "                "); lcd.print(0,1, "New 6-digit code"); break;    
     case 0xC6: lcd.print(0,1, "                "); lcd.print(0,1, "Zone fault menu"); break;
     case 0xC8: lcd.print(0,1, "                "); lcd.print(0,1, "Service required"); break;
+    case 0xCE: lcd.print(0,1, "                "); lcd.print(0,1, "Active cam. mon."); break;    
     case 0xD0: lcd.print(0,1, "                "); lcd.print(0,1, "Keypads low batt"); break;
     case 0xD1: lcd.print(0,1, "                "); lcd.print(0,1, "Wireless low bat"); break;
     case 0xE4: lcd.print(0,1, "                "); lcd.print(0,1, "Installer menu"); break;
@@ -822,12 +828,17 @@ void setStatus(byte partition) {
     case 0xEC: lcd.print(0,1, "                "); lcd.print(0,1, "Input: 6 digits"); break;
     case 0xED: lcd.print(0,1, "                "); lcd.print(0,1, "Input: 32 digits"); break;
     case 0xEE: lcd.print(0,1, "                "); lcd.print(0,1, "Input: option"); break;
+    case 0xEF: lcd.print(0,1, "                "); lcd.print(0,1, "Supv. modules"); break;    
     case 0xF0: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 1"); break;
     case 0xF1: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 2"); break;
     case 0xF2: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 3"); break;
     case 0xF3: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 4"); break;
     case 0xF4: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 5"); break;
+    case 0xF5: lcd.print(0,1, "                "); lcd.print(0,1, "Wls. place. test"); break; 
+    case 0xF6: lcd.print(0,1, "                "); lcd.print(0,1, "Activate device"); break; 
+    case 0xF7: lcd.print(0,1, "                "); lcd.print(0,1, "*8PGM subsection"); break;
     case 0xF8: lcd.print(0,1, "                "); lcd.print(0,1, "Keypad program"); break;
+    case 0xFA: lcd.print(0,1, "                "); lcd.print(0,1, "Input: 6 digits"); break;    
     default: return;
   }
 }

--- a/examples/esp8266/VirtualKeypad-Blynk/VirtualKeypad-Blynk.ino
+++ b/examples/esp8266/VirtualKeypad-Blynk/VirtualKeypad-Blynk.ino
@@ -773,14 +773,18 @@ void setStatus(byte partition) {
     case 0x0B: lcd.print(0,1, "                "); lcd.print(0,1, "Quick exit"); break;
     case 0x0C: lcd.print(0,1, "                "); lcd.print(0,1, "Entry delay"); break;
     case 0x0D: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm memory"); break;
+    case 0x0E: lcd.print(0,1, "                "); lcd.print(0,1, "Not available"); break;    
     case 0x10: lcd.print(0,1, "                "); lcd.print(0,1, "Keypad lockout"); break;
     case 0x11: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm"); break;
+    case 0x12: lcd.print(0,1, "                "); lcd.print(0,1, "Battery check"); break;    
     case 0x14: lcd.print(0,1, "                "); lcd.print(0,1, "Auto-arm"); break;
     case 0x15: lcd.print(0,1, "                "); lcd.print(0,1, "Arm with bypass"); break;
     case 0x16: lcd.print(0,1, "                "); lcd.print(0,1, "No entry delay"); break;
-    case 0x22: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm memory"); break;
+    case 0x19: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm occured"); break;    
+    case 0x22: lcd.print(0,1, "                "); lcd.print(0,1, "Recent closing"); break;
+    case 0x2F: lcd.print(0,1, "                "); lcd.print(0,1, "LCD Pixel check"); break;
     case 0x33: lcd.print(0,1, "                "); lcd.print(0,1, "Busy"); break;
-    case 0x3D: lcd.print(0,1, "                "); lcd.print(0,1, "Disarmed"); break;
+    case 0x3D: lcd.print(0,1, "                "); lcd.print(0,1, "Alarm occured"); break;
     case 0x3E: lcd.print(0,1, "                "); lcd.print(0,1, "Disarmed"); break;
     case 0x40: lcd.print(0,1, "                "); lcd.print(0,1, "Keypad blanked"); break;
     case 0x8A: lcd.print(0,1, "                "); lcd.print(0,1, "Activate zones"); break;
@@ -796,7 +800,7 @@ void setStatus(byte partition) {
     case 0xA4: lcd.print(0,1, "                "); lcd.print(0,1, "Door chime off"); break;
     case 0xA5: lcd.print(0,1, "                "); lcd.print(0,1, "Master code"); break;
     case 0xA6: lcd.print(0,1, "                "); lcd.print(0,1, "Access codes"); break;
-    case 0xA7: lcd.print(0,1, "                "); lcd.print(0,1, "Enter new code"); break;
+    case 0xA7: lcd.print(0,1, "                "); lcd.print(0,1, "New 4-digit code"); break;
     case 0xA9: lcd.print(0,1, "                "); lcd.print(0,1, "User function"); break;
     case 0xAA: lcd.print(0,1, "                "); lcd.print(0,1, "Time and Date"); break;
     case 0xAB: lcd.print(0,1, "                "); lcd.print(0,1, "Auto-arm time"); break;
@@ -809,8 +813,10 @@ void setStatus(byte partition) {
     case 0xB8: lcd.print(0,1, "                "); lcd.print(0,1, "Enter * code"); break;
     case 0xB9: lcd.print(0,1, "                "); lcd.print(0,1, "Zone tamper"); break;
     case 0xBA: lcd.print(0,1, "                "); lcd.print(0,1, "Zones low batt."); break;
+    case 0xBC: lcd.print(0,1, "                "); lcd.print(0,1, "New 6-digit code"); break;    
     case 0xC6: lcd.print(0,1, "                "); lcd.print(0,1, "Zone fault menu"); break;
     case 0xC8: lcd.print(0,1, "                "); lcd.print(0,1, "Service required"); break;
+    case 0xCE: lcd.print(0,1, "                "); lcd.print(0,1, "Active cam. mon."); break;    
     case 0xD0: lcd.print(0,1, "                "); lcd.print(0,1, "Keypads low batt"); break;
     case 0xD1: lcd.print(0,1, "                "); lcd.print(0,1, "Wireless low bat"); break;
     case 0xE4: lcd.print(0,1, "                "); lcd.print(0,1, "Installer menu"); break;
@@ -823,12 +829,17 @@ void setStatus(byte partition) {
     case 0xEC: lcd.print(0,1, "                "); lcd.print(0,1, "Input: 6 digits"); break;
     case 0xED: lcd.print(0,1, "                "); lcd.print(0,1, "Input: 32 digits"); break;
     case 0xEE: lcd.print(0,1, "                "); lcd.print(0,1, "Input: option"); break;
+    case 0xEF: lcd.print(0,1, "                "); lcd.print(0,1, "Supv. modules"); break;    
     case 0xF0: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 1"); break;
     case 0xF1: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 2"); break;
     case 0xF2: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 3"); break;
     case 0xF3: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 4"); break;
     case 0xF4: lcd.print(0,1, "                "); lcd.print(0,1, "Function key 5"); break;
+    case 0xF5: lcd.print(0,1, "                "); lcd.print(0,1, "Wls. place. test"); break; 
+    case 0xF6: lcd.print(0,1, "                "); lcd.print(0,1, "Activate device"); break; 
+    case 0xF7: lcd.print(0,1, "                "); lcd.print(0,1, "*8PGM subsection"); break;
     case 0xF8: lcd.print(0,1, "                "); lcd.print(0,1, "Keypad program"); break;
+    case 0xFA: lcd.print(0,1, "                "); lcd.print(0,1, "Input: 6 digits"); break;    
     default: return;
   }
 }

--- a/examples/esp8266/VirtualKeypad-Web/VirtualKeypad-Web.ino
+++ b/examples/esp8266/VirtualKeypad-Web/VirtualKeypad-Web.ino
@@ -287,13 +287,17 @@ void setStatus(byte partition) {
       case 0x0B: root["lcd_lower"] = "Quick exit"; break;
       case 0x0C: root["lcd_lower"] = "Entry delay"; break;
       case 0x0D: root["lcd_lower"] = "Alarm memory"; break;
+      case 0x0E: root["lcd_lower"] = "Not available"; break;      
       case 0x10: root["lcd_lower"] = "Keypad lockout"; break;
       case 0x11: root["lcd_lower"] = "Alarm"; break;
+      case 0x12: root["lcd_lower"] = "Battery check"; break;      
       case 0x14: root["lcd_lower"] = "Auto-arm"; break;
       case 0x16: root["lcd_lower"] = "No entry delay"; break;
-      case 0x22: root["lcd_lower"] = "Alarm memory"; break;
+      case 0x19: root["lcd_lower"] = "Alarm occured"; break;      
+      case 0x22: root["lcd_lower"] = "Recent closing"; break;
+      case 0x2F: root["lcd_lower"] = "LCD Pixel check"; break;
       case 0x33: root["lcd_lower"] = "Busy"; break;
-      case 0x3D: root["lcd_lower"] = "Disarmed"; break;
+      case 0x3D: root["lcd_lower"] = "Alarm occured"; break;
       case 0x3E: root["lcd_lower"] = "Disarmed"; break;
       case 0x40: root["lcd_lower"] = "Keypad blanked"; break;
       case 0x8A: root["lcd_lower"] = "Activate zones"; break;
@@ -309,7 +313,7 @@ void setStatus(byte partition) {
       case 0xA4: root["lcd_lower"] = "Door chime off"; break;
       case 0xA5: root["lcd_lower"] = "Master code"; break;
       case 0xA6: root["lcd_lower"] = "Access codes"; break;
-      case 0xA7: root["lcd_lower"] = "Enter new code"; break;
+      case 0xA7: root["lcd_lower"] = "New 4-digit code"; break;
       case 0xA9: root["lcd_lower"] = "User function"; break;
       case 0xAA: root["lcd_lower"] = "Time and Date"; break;
       case 0xAB: root["lcd_lower"] = "Auto-arm time"; break;
@@ -322,6 +326,8 @@ void setStatus(byte partition) {
       case 0xB8: root["lcd_lower"] = "Enter * code"; break;
       case 0xB9: root["lcd_lower"] = "Zone tamper"; break;
       case 0xBA: root["lcd_lower"] = "Zones low batt."; break;
+      case 0xBC: root["lcd_lower"] = "New 6-digit code"; break;      
+      case 0xCE: root["lcd_lower"] = "Active cam. mon."; break;      
       case 0xC6: root["lcd_lower"] = "Zone fault menu"; break;
       case 0xC8: root["lcd_lower"] = "Service required"; break;
       case 0xD0: root["lcd_lower"] = "Keypads low batt"; break;
@@ -336,12 +342,17 @@ void setStatus(byte partition) {
       case 0xEC: root["lcd_lower"] = "Input: 6 digits"; break;
       case 0xED: root["lcd_lower"] = "Input: 32 digits"; break;
       case 0xEE: root["lcd_lower"] = "Input: option"; break;
+      case 0xEF: root["lcd_lower"] = "Supv. modules"; break;      
       case 0xF0: root["lcd_lower"] = "Function key 1"; break;
       case 0xF1: root["lcd_lower"] = "Function key 2"; break;
       case 0xF2: root["lcd_lower"] = "Function key 3"; break;
       case 0xF3: root["lcd_lower"] = "Function key 4"; break;
       case 0xF4: root["lcd_lower"] = "Function key 5"; break;
+      case 0xF5: root["lcd_lower"] = "Wls. place. test"; break;
+      case 0xF6: root["lcd_lower"] = "Activate device"; break;
+      case 0xF7: root["lcd_lower"] = "*8PGM subsection"; break;      
       case 0xF8: root["lcd_lower"] = "Keypad program"; break;
+      case 0xFA: root["lcd_lower"] = "Input: 6 digits"; break;      
       default: root["lcd_lower"] = dsc.status[partition];
     }
     serializeJson(root, outas);

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -185,7 +185,7 @@ class dscKeybusInterface {
     void printPanelTone(byte panelByte);
     void printPanelBuzzer(byte panelByte);
     bool printPanelZones(byte inputByte, byte startZone);
-    void printPanelAccessCode(byte dscCode, bool accessIncrease = true);
+    void printPanelAccessCode(byte dscCode, bool accessCodeIncrease = true);
     void printPanelBitNumbers(byte panelByte, byte startNumber, byte startBit = 0, byte stopBit = 7, bool printNone = true);
     void printNumberSpace(byte number);
     void printNumberOffset(byte panelByte, int numberOffset);

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -172,7 +172,13 @@ class dscKeybusInterface {
     void printPanelStatus2(byte panelByte);
     void printPanelStatus3(byte panelByte);
     void printPanelStatus4(byte panelByte);
-    void printPanelStatus1X(byte panelByte);
+    void printPanelStatus5(byte panelByte);
+    void printPanelStatus14(byte panelByte);
+    void printPanelStatus17(byte panelByte);
+    void printPanelStatus18(byte panelByte);
+    void printPanelStatus1B(byte panelByte);
+  
+
     void printPanelMessages(byte panelByte);
     void printPanelLights(byte panelByte, bool printMessage = true);
     void printPanelTime(byte panelByte);

--- a/src/dscKeybusInterface.h
+++ b/src/dscKeybusInterface.h
@@ -176,8 +176,7 @@ class dscKeybusInterface {
     void printPanelStatus14(byte panelByte);
     void printPanelStatus17(byte panelByte);
     void printPanelStatus18(byte panelByte);
-    void printPanelStatus1B(byte panelByte);
-  
+    void printPanelStatus1B(byte panelByte);  
 
     void printPanelMessages(byte panelByte);
     void printPanelLights(byte panelByte, bool printMessage = true);
@@ -186,7 +185,7 @@ class dscKeybusInterface {
     void printPanelTone(byte panelByte);
     void printPanelBuzzer(byte panelByte);
     bool printPanelZones(byte inputByte, byte startZone);
-    void printPanelAccessCode(byte dscCode);
+    void printPanelAccessCode(byte dscCode, bool accessIncrease = true);
     void printPanelBitNumbers(byte panelByte, byte startNumber, byte startBit = 0, byte stopBit = 7, bool printNone = true);
     void printNumberSpace(byte number);
     void printNumberOffset(byte panelByte, int numberOffset);
@@ -223,7 +222,7 @@ class dscKeybusInterface {
     void printPanel_0x94();
     void printPanel_0x9E();
     void printPanel_0xA5();
-	void printPanel_0xAA();
+    void printPanel_0xAA();
     void printPanel_0xB1();
     void printPanel_0xBB();
     void printPanel_0xC3();

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -1972,6 +1972,8 @@ void dscKeybusInterface::printPanel_0xBB() {
  *  Content decoding: *incomplete
  *
  *  Byte 2: Keypad status, incomplete
+ *  Byte 2: bit3 and 4 active when dialer attempt begin
+ *  Byte 2: bit4 active after dialer attempt finished
  *  Byte 3: Unknown, always observed as 11111111
  *  Byte 4: CRC
  *
@@ -1986,6 +1988,8 @@ void dscKeybusInterface::printPanel_0xC3() {
   if (panelData[3] == 0xFF) {
     switch (panelData[2]) {
       case 0x00: stream->print(F("Keypad ready")); break;
+      case 0x10: stream->print(F("Dialer finished")); break;
+      case 0x18: stream->print(F("Dialer attempt")); break;
       case 0x30:
       case 0x40: stream->print(F("Keypad lockout")); break;
       default: printUnknownData(); break;

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -219,6 +219,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     //case 0x17: break;  // Observed in logs, unknown message
     case 0x19: stream->print(F("Disarmed after alarm in memory")); break;
     case 0x22: stream->print(F("Recent closing")); break;
+    case 0x2F: stream->print(F("Keypad LCD screen pixel test")); break;
     case 0x33: stream->print(F("Command output in progress")); break;
     case 0x3D: stream->print(F("Disarmed after alarm in memory")); break;
     case 0x3E: stream->print(F("Partition disarmed")); break;
@@ -252,6 +253,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     case 0xBC: stream->print(F("*5: Enter new 6-digit code")); break;    
     case 0xC6: stream->print(F("*2: Zone fault menu")); break;
     case 0xC8: stream->print(F("*2: Service required menu")); break;
+    case 0xCE: stream->print(F("Active camera monitor selection")); break;    
     // case 0xCD: Enter DLS (?)
     case 0xD0: stream->print(F("*2: Handheld keypads with low batteries")); break;
     case 0xD1: stream->print(F("*2: Wireless keys with low batteries")); break;
@@ -355,17 +357,18 @@ void dscKeybusInterface::printPanelStatus0(byte panelByte) {
     case 0xE7: stream->print(F("Panel battery trouble")); break;
     case 0xE8: stream->print(F("Panel AC power trouble")); break;
     case 0xE9: stream->print(F("Bell trouble")); break;
-    case 0xEA: stream->print(F("PGM2 input trouble")); break;
+    case 0xEA: stream->print(F("Fire zone trouble")); break;
     case 0xEB: stream->print(F("Panel aux supply trouble")); break;
     case 0xEC: stream->print(F("Telephone line trouble")); break;
     case 0xEF: stream->print(F("Panel battery restored")); break;
     case 0xF0: stream->print(F("Panel AC power restored")); break;
     case 0xF1: stream->print(F("Bell restored")); break;
-    case 0xF2: stream->print(F("PGM2 input restored")); break;
+    case 0xF2: stream->print(F("Fire zone trouble restored")); break;
     case 0xF3: stream->print(F("Panel aux supply restored")); break;
     case 0xF4: stream->print(F("Telephone line restored")); break;
     case 0xF7: stream->print(F("Phone 1 FTC")); break;
     case 0xF8: stream->print(F("Phone 2 FTC")); break;
+    case 0xF9: stream->print(F("Event buffer treshold (75% full since last DLS upload)")); break;
     case 0xFA: stream->print(F("DLS lead-in")); break;
     case 0xFB: stream->print(F("DLS lead-out")); break;
     case 0xFE: stream->print(F("Periodic test transmission")); break;
@@ -3355,12 +3358,17 @@ void dscKeybusInterface::printModule_KeyCodes(byte keyByte) {
     case 0x2D: stream->print(F("# ")); break;
     case 0x46: stream->print(F("Wireless key disarm ")); break;
     case 0x52: stream->print(F("Identified voice prompt help ")); break;
+    case 0x6E: stream->print(F("Global away arm ")); break;
     case 0x70: stream->print(F("Command output 3 ")); break;
+    case 0x7A: stream->print(F("Time and date programming ")); break;
     case 0x75: stream->print(F("Entered *1/*2/*3 menu (?) ")); break;
     case 0x82: stream->print(F("Enter ")); break;
     case 0x87: stream->print(F("Right arrow ")); break;
     case 0x88: stream->print(F("Left arrow ")); break;
+    case 0x8D: stream->print(F("Bypass recall ")); break;
+    case 0x93: stream->print(F("Recall bypass group ")); break;
     case 0x94: stream->print(F("Label broadcast announce ")); break;
+    case 0x99: stream->print(F("Function key [25] Future Use ")); break;
     case 0xA5: stream->print(F("Data successfully received ")); break;
     case 0xAF: stream->print(F("Arm: Stay ")); break;
     case 0xB1: stream->print(F("Arm: Away ")); break;
@@ -3374,11 +3382,12 @@ void dscKeybusInterface::printModule_KeyCodes(byte keyByte) {
     case 0xD0: stream->print(F("*6 Programming ")); break;
     case 0xD5: stream->print(F("Command output 1 ")); break;
     case 0xDA: stream->print(F("Reset / Command output 2 ")); break;
-    case 0xDF: stream->print(F("General voice prompt help ")); break;
+    case 0xDF: stream->print(F("Global stay arm ")); break; //General voice prompt help on panels v4.1 and below
     case 0xE1: stream->print(F("Quick exit ")); break;
     case 0xE6: stream->print(F("Activate stay/away zones ")); break;
-    case 0xEB: stream->print(F("Function key [20] Future Use ")); break;
+    case 0xEB: stream->print(F("LCD display pixel test ")); break;
     case 0xEC: stream->print(F("Command output 4 ")); break;
+    case 0xF2: stream->print(F("Global disarm ")); break;
     case 0xF7: stream->print(F("Menu navigation ")); break;
   }
 }

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -3349,6 +3349,8 @@ void dscKeybusInterface::printModule_KeyCodes(byte keyByte) {
     case 0x82: stream->print(F("Enter ")); break;
     case 0x87: stream->print(F("Right arrow ")); break;
     case 0x88: stream->print(F("Left arrow ")); break;
+    case 0x94: stream->print(F("Global label broadcast start ")); break;
+    case 0xA5: stream->print(F("Data successfully received ")); break;
     case 0xAF: stream->print(F("Arm: Stay ")); break;
     case 0xB1: stream->print(F("Arm: Away ")); break;
     case 0xB6: stream->print(F("Arm: No entry delay ")); break;
@@ -3514,9 +3516,9 @@ void dscKeybusInterface::printPanelTime(byte panelByte) {
  *  Structure decoding: complete
  *  Content decoding: complete
  */
-void dscKeybusInterface::printPanelAccessCode(byte dscCode, bool accessIncrease) {
+void dscKeybusInterface::printPanelAccessCode(byte dscCode, bool accessCodeIncrease) {
   
-  if (accessIncrease) {
+  if (accessCodeIncrease) {
     if (dscCode >= 35) dscCode += 5;
   }  
   else {

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -212,6 +212,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     case 0x0E: stream->print(F("Function not available")); break;
     case 0x10: stream->print(F("Keypad lockout")); break;
     case 0x11: stream->print(F("Partition in alarm")); break;
+    case 0x12: stream->print(F("Battery check in progress")); break;
     case 0x14: stream->print(F("Auto-arm in progress")); break;
     case 0x15: stream->print(F("Arming with bypassed zones")); break;
     case 0x16: stream->print(F("Armed with no entry delay")); break;
@@ -1690,7 +1691,8 @@ void dscKeybusInterface::printPanel_0x82() {
  *  Byte 2 bit 7: PGM 10
  *  Byte 3 bit 0: PGM 1
  *  Byte 3 bit 1: PGM 2
- *  Byte 3 bit 2-3: Unknown
+ *  Byte 3 bit 2: Activates at midnight
+ *  Byte 3 bit 3: Battery check when arming
  *  Byte 3 bit 4: PGM 11
  *  Byte 3 bit 5: PGM 12
  *  Byte 3 bit 6: PGM 13
@@ -1710,7 +1712,8 @@ void dscKeybusInterface::printPanel_0x82() {
  */
 void dscKeybusInterface::printPanel_0x87() {
   stream->print(F("PGM outputs enabled: "));
-
+  if (panelData[3] & 0x04) stream->print(F("Midnight | "));
+  if (panelData[3] & 0x08) stream->print(F("Battery check | "));
   if (panelData[2] == 0 && panelData[3] == 0) stream->print(F("none"));
   else {
     printPanelBitNumbers(3, 1, 0, 1, false);
@@ -2820,10 +2823,10 @@ void dscKeybusInterface::printModule_Status() {
     printedMessage = true;
   }
 
-  //Unknown notification
+  //Keypad going idle notification
   if (moduleByteCount > 6 && (moduleData[7] & 0x08) == 0) {
     if (printedMessage) stream->print("| ");
-    stream->print(F("Unknown notification "));
+    stream->print(F("Keypad idle notification "));
     printedMessage = true;
   }
 
@@ -3346,10 +3349,11 @@ void dscKeybusInterface::printModule_KeyCodes(byte keyByte) {
     case 0x46: stream->print(F("Wireless key disarm ")); break;
     case 0x52: stream->print(F("Identified voice prompt help ")); break;
     case 0x70: stream->print(F("Command output 3 ")); break;
+    case 0x75: stream->print(F("Entered *1/*2/*3 menu (?) ")); break;
     case 0x82: stream->print(F("Enter ")); break;
     case 0x87: stream->print(F("Right arrow ")); break;
     case 0x88: stream->print(F("Left arrow ")); break;
-    case 0x94: stream->print(F("Global label broadcast start ")); break;
+    case 0x94: stream->print(F("Label broadcast announce ")); break;
     case 0xA5: stream->print(F("Data successfully received ")); break;
     case 0xAF: stream->print(F("Arm: Stay ")); break;
     case 0xB1: stream->print(F("Arm: Away ")); break;

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -868,10 +868,30 @@ void dscKeybusInterface::printPanelStatus4(byte panelByte) {
  
 void dscKeybusInterface::printPanelStatus5(byte panelByte) {
 /*
- *  Access codes 35-39 and 43-95 for disarming/arming/*9 arming
- *  0x00 ... arming with user code 35
- *  0x3A ... disarming with user code 35
+ *  Armed by access code
+ *  0x00 ... 0x04 user 35..39  
+ *  0x05 ... 0x39 user 43..95
  */
+
+  if (panelData[panelByte] >= 0x00 && panelData[panelByte] <= 0x39) {
+    byte dscCode = panelData[panelByte] + 0x23;
+    stream->print(F("Armed: "));
+    printPanelAccessCode(dscCode, false);
+    return;
+  }
+
+  /*
+   *  Disarmed by access code
+   *  0x3A ... 0x3E user 35..39
+   *  0x3F ... 0x73 user 43..95
+   */
+  if (panelData[panelByte] >= 0x3A && panelData[panelByte] <= 0x73) {
+    byte dscCode = panelData[panelByte] - 0x17;
+    stream->print(F("Disarmed: "));
+    printPanelAccessCode(dscCode, false);
+    return;
+  }
+ 
   printUnknownData();
 }
 
@@ -887,26 +907,20 @@ void dscKeybusInterface::printPanelStatus14(byte panelByte) {
 
 void dscKeybusInterface::printPanelStatus17(byte panelByte) {
   /*
-   * 0x00 - 0x24: *2: Access code 1-32, 40, 41, 42
-   * 0x25 - 0x49: *3: Access code 1-32, 40, 41, 42
-   * 0x4A - 0x83: *1: User codes 35..39 and 43..95
-   * 0x84 - 0xBD: *2: User codes 35..39 and 43..95
-   * 0xBE - 0xF7: *3: User codes 35..39 and 43..95   
-   */
-     
-
-  /*
    *  *1: Access code
+   *  0x4A - 0x83: *1: User codes 35..39 and 43..95
    */
-  if (panelData[panelByte] >= 0x4F && panelData[panelByte] <= 0x83) {
-    byte dscCode = panelData[panelByte] - 0x29;
+  if (panelData[panelByte] >= 0x4A && panelData[panelByte] <= 0x83) {
+    byte dscCode = panelData[panelByte] - 0x27;
     stream->print(F("*1: "));
-    printPanelAccessCode(dscCode);
+    printPanelAccessCode(dscCode, false);
     return;
   }
 
   /*
    *  *2: Access code
+   *  0x00 - 0x24: *2: Access code 1-32, 40, 41, 42
+   *  0x84 - 0xBD: *2: User codes 35..39 and 43..95
    */
   if (panelData[panelByte] >= 0 && panelData[panelByte] <= 0x24) {
     byte dscCode = panelData[panelByte] + 1;
@@ -914,15 +928,17 @@ void dscKeybusInterface::printPanelStatus17(byte panelByte) {
     printPanelAccessCode(dscCode);
     return;
   }
-  if (panelData[panelByte] >= 0x89 && panelData[panelByte] <= 0xBD) {
-    byte dscCode = panelData[panelByte] - 0x63;
+  if (panelData[panelByte] >= 0x84 && panelData[panelByte] <= 0xBD) {
+    byte dscCode = panelData[panelByte] - 0x61;
     stream->print(F("*2: "));
-    printPanelAccessCode(dscCode);
+    printPanelAccessCode(dscCode, false);
     return;
   }
 
   /*
    *  *3: Access code
+   *  0x25 - 0x49: *3: Access code 1-32, 40, 41, 42
+   *  0xBE - 0xF7: *3: User codes 35..39 and 43..95 
    */
   if (panelData[panelByte] >= 0x25 && panelData[panelByte] <= 0x49) {
     byte dscCode = panelData[panelByte] - 0x24;
@@ -930,10 +946,10 @@ void dscKeybusInterface::printPanelStatus17(byte panelByte) {
     printPanelAccessCode(dscCode);
     return;
   }
-  if (panelData[panelByte] >= 0xC3 && panelData[panelByte] <= 0xF7) {
-    byte dscCode = panelData[panelByte] - 0x9D;
+  if (panelData[panelByte] >= 0xBE && panelData[panelByte] <= 0xF7) {
+    byte dscCode = panelData[panelByte] - 0x9B;
     stream->print(F("*3: "));
-    printPanelAccessCode(dscCode);
+    printPanelAccessCode(dscCode, false);
     return;
   }
   
@@ -942,38 +958,41 @@ void dscKeybusInterface::printPanelStatus17(byte panelByte) {
 
 void dscKeybusInterface::printPanelStatus18(byte panelByte) {
   /*
-   * 0x00 - 0x39: *7/*User codes 35..39 and 43..95
-   * 0x5C - 0x95: *5: User codes 35..39 and 43..95
-   * 0xB8 - 0xF1: *6: User codes 35..39 and 43..95
+   *  *7/User/Auto-arm cancel by Access code
+   *  
+   * 0x00 - 0x04: *7/*User codes 35..39
+   * 0x05 - 0x39: *7/*User codes 43..95
    */
-
-  /*
-   *  *7: Access code
-   */
-  if (panelData[panelByte] >= 0x05 && panelData[panelByte] <= 0x39) {
-    byte dscCode = panelData[panelByte] + 0x21;
+  if (panelData[panelByte] >= 0x00 && panelData[panelByte] <= 0x39) {
+    byte dscCode = panelData[panelByte] + 0x23;
     stream->print(F("User code: "));
-    printPanelAccessCode(dscCode);
+    printPanelAccessCode(dscCode, false);
     return;
   }
 
   /*
    *  *5: Access code
+   *  
+   * 0x3A - 0x60: *5: User codes 1..39    
+   * 0x61 - 0x95: *5: User codes 43..95
    */
-  if (panelData[panelByte] >= 0x61 && panelData[panelByte] <= 0x95) {
-    byte dscCode = panelData[panelByte] - 0x3B;
+  if (panelData[panelByte] >= 0x3A && panelData[panelByte] <= 0x95) {
+    byte dscCode = panelData[panelByte] - 0x39;
     stream->print(F("*5: "));
-    printPanelAccessCode(dscCode);
+    printPanelAccessCode(dscCode, false);
     return;
   }
 
   /*
    *  *6: Access code
+   *  
+   * 0x96 - 0xBC: *6: User codes 1..39
+   * 0xBD - 0xF1: *6: User codes 43..95  
    */
-  if (panelData[panelByte] >= 0xBD && panelData[panelByte] <= 0xF1) {
-    byte dscCode = panelData[panelByte] - 0x97;
+  if (panelData[panelByte] >= 0x96 && panelData[panelByte] <= 0xF1) {
+    byte dscCode = panelData[panelByte] - 0x95;
     stream->print(F("*6: "));
-    printPanelAccessCode(dscCode);
+    printPanelAccessCode(dscCode, false);
     return;
   }
 
@@ -3493,8 +3512,15 @@ void dscKeybusInterface::printPanelTime(byte panelByte) {
  *  Structure decoding: complete
  *  Content decoding: complete
  */
-void dscKeybusInterface::printPanelAccessCode(byte dscCode) {
-  if (dscCode >= 35) dscCode += 5;
+void dscKeybusInterface::printPanelAccessCode(byte dscCode, bool accessIncrease) {
+  
+  if (accessIncrease) {
+    if (dscCode >= 35) dscCode += 5;
+  }  
+  else {
+    if (dscCode >= 40) dscCode += 3;
+  }
+  
 
   switch (dscCode) {
     case 33: stream->print(F("Duress ")); break;

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -1988,10 +1988,11 @@ void dscKeybusInterface::printPanel_0xC3() {
   if (panelData[3] == 0xFF) {
     switch (panelData[2]) {
       case 0x00: stream->print(F("Keypad ready")); break;
-      case 0x10: stream->print(F("Dialer finished")); break;
-      case 0x18: stream->print(F("Dialer attempt")); break;
+      case 0x10: stream->print(F("Dialer attempts finished")); break;
+      case 0x18: stream->print(F("Dialer call attempt")); break;
       case 0x30:
       case 0x40: stream->print(F("Keypad lockout")); break;
+      case 0x38: stream->print(F("Dialer call attempt while keypad lockout")); break;
       default: printUnknownData(); break;
     }
   }

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -355,11 +355,13 @@ void dscKeybusInterface::printPanelStatus0(byte panelByte) {
     case 0xE7: stream->print(F("Panel battery trouble")); break;
     case 0xE8: stream->print(F("Panel AC power trouble")); break;
     case 0xE9: stream->print(F("Bell trouble")); break;
+    case 0xEA: stream->print(F("PGM2 input trouble")); break;
     case 0xEB: stream->print(F("Panel aux supply trouble")); break;
     case 0xEC: stream->print(F("Telephone line trouble")); break;
     case 0xEF: stream->print(F("Panel battery restored")); break;
     case 0xF0: stream->print(F("Panel AC power restored")); break;
     case 0xF1: stream->print(F("Bell restored")); break;
+    case 0xF2: stream->print(F("PGM2 input restored")); break;
     case 0xF3: stream->print(F("Panel aux supply restored")); break;
     case 0xF4: stream->print(F("Telephone line restored")); break;
     case 0xF7: stream->print(F("Phone 1 FTC")); break;

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -235,7 +235,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     case 0xA4: stream->print(F("Door chime disabled")); break;
     case 0xA5: stream->print(F("Enter master code")); break;
     case 0xA6: stream->print(F("*5: Access codes")); break;
-    case 0xA7: stream->print(F("*5: Enter new code")); break;
+    case 0xA7: stream->print(F("*5: Enter new 4-digit code")); break;
     case 0xA9: stream->print(F("*6: User functions")); break;
     case 0xAA: stream->print(F("*6: Time and date")); break;
     case 0xAB: stream->print(F("*6: Auto-arm time")); break;
@@ -248,6 +248,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     case 0xB8: stream->print(F("Key * while armed")); break;
     case 0xB9: stream->print(F("*2: Zone tamper menu")); break;
     case 0xBA: stream->print(F("*2: Zones with low batteries")); break;
+    case 0xBC: stream->print(F("*5: Enter new 6-digit code")); break;    
     case 0xC6: stream->print(F("*2: Zone fault menu")); break;
     case 0xC8: stream->print(F("*2: Service required menu")); break;
     // case 0xCD: Enter DLS (?)
@@ -272,6 +273,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     case 0xF5: stream->print(F("Wireless module placement test")); break;
     case 0xF7: stream->print(F("Installer programming subsection")); break;
     case 0xF8: stream->print(F("Keypad programming")); break;
+    case 0xFA: stream->print(F("Input 6 digits")); break;    
     default:
       printUnknownData();
       stream->print(F(": 0x"));

--- a/src/dscKeybusPrintData.cpp
+++ b/src/dscKeybusPrintData.cpp
@@ -219,7 +219,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     //case 0x17: break;  // Observed in logs, unknown message
     case 0x19: stream->print(F("Disarmed after alarm in memory")); break;
     case 0x22: stream->print(F("Recent closing")); break;
-    case 0x2F: stream->print(F("Keypad LCD screen pixel test")); break;
+    case 0x2F: stream->print(F("Keypad LCD test")); break;
     case 0x33: stream->print(F("Command output in progress")); break;
     case 0x3D: stream->print(F("Disarmed after alarm in memory")); break;
     case 0x3E: stream->print(F("Partition disarmed")); break;
@@ -255,8 +255,8 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     case 0xC8: stream->print(F("*2: Service required menu")); break;
     case 0xCE: stream->print(F("Active camera monitor selection")); break;    
     // case 0xCD: Enter DLS (?)
-    case 0xD0: stream->print(F("*2: Handheld keypads with low batteries")); break;
-    case 0xD1: stream->print(F("*2: Wireless keys with low batteries")); break;
+    case 0xD0: stream->print(F("*2: Keypads with low batteries")); break;
+    case 0xD1: stream->print(F("*2: Keysfobs with low batteries")); break;
     case 0xE4: stream->print(F("*8: Installer programming")); break;
     case 0xE5: stream->print(F("Keypad slot assignment")); break;
     case 0xE6: stream->print(F("Input 2 digits")); break;
@@ -274,6 +274,7 @@ void dscKeybusInterface::printPanelMessages(byte panelByte) {
     case 0xF3: stream->print(F("Function key 4")); break;
     case 0xF4: stream->print(F("Function key 5")); break;
     case 0xF5: stream->print(F("Wireless module placement test")); break;
+    case 0xF6: stream->print(F("Activate device for test")); break;
     case 0xF7: stream->print(F("Installer programming subsection")); break;
     case 0xF8: stream->print(F("Keypad programming")); break;
     case 0xFA: stream->print(F("Input 6 digits")); break;    
@@ -368,7 +369,7 @@ void dscKeybusInterface::printPanelStatus0(byte panelByte) {
     case 0xF4: stream->print(F("Telephone line restored")); break;
     case 0xF7: stream->print(F("Phone 1 FTC")); break;
     case 0xF8: stream->print(F("Phone 2 FTC")); break;
-    case 0xF9: stream->print(F("Event buffer treshold (75% full since last DLS upload)")); break;
+    case 0xF9: stream->print(F("Event buffer treshold")); break; //75% full since last DLS upload
     case 0xFA: stream->print(F("DLS lead-in")); break;
     case 0xFB: stream->print(F("DLS lead-out")); break;
     case 0xFE: stream->print(F("Periodic test transmission")); break;
@@ -500,15 +501,19 @@ void dscKeybusInterface::printPanelStatus1(byte panelByte) {
     case 0x03: stream->print(F("Cross zone alarm")); return;
     case 0x04: stream->print(F("Delinquency alarm")); return;
     // 0x24 - 0x28: Access code
+    case 0x29: stream->print(F("Downloading forced answer")); return;
     case 0x2B: stream->print(F("Armed: Auto-arm")); return;
     // 0x6C - 0x8B: Zone fault restored, zones 1-32
     // 0x8C - 0xAB: Zone fault, zones 1-32
     case 0xAC: stream->print(F("Exit installer programming")); return;
     case 0xAD: stream->print(F("Enter installer programming")); return;
+    case 0xAE: stream->print(F("Walk test end")); return;
+    case 0xAF: stream->print(F("Walk test begin")); return;
     // 0xB0 - 0xCF: Zones bypassed, zones 1-32
     case 0xD0: stream->print(F("Command output 4")); return;
     case 0xD1: stream->print(F("Exit fault pre-alert")); return;
     case 0xD2: stream->print(F("Armed with no entry delay cancelled")); return;
+    case 0xD3: stream->print(F("Downlook remote trigger")); return;
   }
 
   /*
@@ -1730,6 +1735,7 @@ void dscKeybusInterface::printPanel_0x87() {
 
 /*
  *  0x8D: User code programming key response, codes 17-32
+ *  Note: Wireless keys 1-16 are assigned to user codes 17-32
  *  CRC: yes
  *  Structure decoding: *incomplete
  *  Content decoding: *incomplete
@@ -1752,10 +1758,38 @@ void dscKeybusInterface::printPanel_0x87() {
  *  10001101 0 00110001 00100101 00000000 00001001 11111111 11111111 11111111 11101001 [0x8D] User code programming key response  // Code 29 Key 0
  *  10001101 0 00110001 00100101 00000000 00000001 11111111 11111111 11111111 11100001 [0x8D] User code programming key response  // Code 29 Key 1
  *  10001101 0 00110001 00110000 00000000 00000000 11111111 11111111 11111111 11101011 [0x8D] User code programming key response  // Message after 4th key entered
+ *  10001101 0 00010001 01000001 00000001 00000111 01010101 11111111 11111111 00111010 [0x8D] Wls programming key response	  // Before WLS zone 4 placement test
+ *  10001101 0 00010001 01000001 00000001 00001001 01010101 11111111 11111111 00111100 [0x8D] Wls programming key response	  // Before WLS zone 5 placement test
+ *  10001101 0 00010001 01000001 00000001 00001011 01010101 11111111 11111111 00111110 [0x8D] Wls programming key response	  // Before WLS zone 6 placement test
+ *  10001101 0 00010001 01000001 00000001 00001101 01010101 11111111 11111111 01000000 [0x8D] Wls programming key response   	  // Before WLS zone 7 placement test
+ *  10001101 0 00010001 01000001 00000001 00100001 01010101 11111111 11111111 01010100 [0x8D] Wls programming key response	  // Before WLS zone 17 placement test
+ *  10001101 0 00010001 01000001 00000001 00111111 01010101 11111111 11111111 01110010 [0x8D] Wls programming key response	  // Before WLS zone 32 placement test
+ *  10001101 0 00010001 01000001 00000001 01111111 01010101 11111111 11111111 10110010 [0x8D] Wls programming key response	  // Before WLS zone 64 placement test
+ *  10001101 0 00010001 01000011 00000000 00000001 11111111 11111111 11111111 11011111 [0x8D] Wls programming key response	  // Location is good, same for all zones
+ *  10001101 0 00010001 01000001 00000001 11111111 11111111 11111111 11111111 11011100 [0x8D] Wls programming key response	  // Wireless zone is not-assigned
+ *  10001101 0 00010001 10100100 00000000 00000011 11111111 11111111 11111111 01000010 [0x8D] Wls programming key response	  // Enter 03 for [804][61] function 1
+ *  10001101 0 00010001 10100101 00000000 00000100 11111111 11111111 11111111 01000100 [0x8D] Wls programming key response	  // Enter 04 for [804][61] function 2
+ *  10001101 0 00010001 10100101 00000000 00000011 11111111 11111111 11111111 01000011 [0x8D] Wls programming key response	  // Enter 03 for [804][61] function 2
+ *  10001101 0 00010001 10101000 00000000 00000011 11111111 11111111 11111111 01000110 [0x8D] Wls programming key response	  // Enter 03 for [804][62] function 1
+ *  10001101 0 00010001 10101001 00000000 00000100 11111111 11111111 11111111 01001000 [0x8D] Wls programming key response	  // Enter 04 for [804][62] function 2
+ *  10001101 0 00010001 11000000 00000000 00000011 11111111 11111111 11111111 01011110 [0x8D] Wls programming key response	  // Enter 03 for [804][68] function 1
+ *  10001101 0 00010001 11000011 00000000 00110000 11111111 11111111 11111111 10001110 [0x8D] Wls programming key response	  // Enter 30 for [804][68] function 4
+ *  10001101 0 00010001 00111000 00000000 00010000 11111111 11111111 11111111 11100011 [0x8D] Wls programming key response	  // Enter 10 for [804][81] Wls supervisory window
+ *  10001101 0 00010001 00111000 00000000 10010110 11111111 11111111 11111111 01101001 [0x8D] Wls programming key response	  // Enter 96 for [804][81] Wls supervisory window
+ *  10001101 0 00010001 11000100 00000000 00000001 11111111 11111111 11111111 01100000 [0x8D] Wls programming key response	  // Enter 01 for [804][69] Keyfob 1 partition assigment
+ *  10001101 0 00010001 11000101 00000000 00000001 11111111 11111111 11111111 01100001 [0x8D] Wls programming key response	  // Enter 01 for [804][69] Keyfob 2 partition assigment
+ *  10001101 0 00010001 11000110 00000000 00000010 11111111 11111111 11111111 01100011 [0x8D] Wls programming key response	  // Enter 02 for [804][69] Keyfob 3 partition assigment
+ *  10001101 0 00010001 11010100 00000000 11111111 11111111 11111111 11111111 01101110 [0x8D] Wls programming key response	  // All 1-8 enabled in [804][82] supervision options
+ *  10001101 0 00010001 11010100 00000000 11110000 11111111 11111111 11111111 01011111 [0x8D] Wls programming key response	  // 5-8 zones enabled in [804][82] supervisiory options
+ *  10001101 0 00010001 11010101 00000000 00001111 11111111 11111111 11111111 01111111 [0x8D] Wls programming key response	  // 1-4 zones enabled in [804][83] supervisiory options
+ *  10001101 0 00010001 11010111 00000000 01111111 11111111 11111111 11111111 11110001 [0x8D] Wls programming key response	  // 1-7 zones enabled in [804][85] supervisiory options
+ *  10001101 0 00010001 00111010 00000000 01000000 11111111 11111111 11111111 00010101 [0x8D] Wls programming key response	  // Only option 7 enabled in [804][90] options
+ *  10001101 0 00010001 00111001 00000000 00001000 11111111 11111111 11111111 11011100 [0x8D] Wls programming key response	  // Set RF jamming zone 08 in [804][93] subsection
+ *  10001101 0 00010001 00111001 00000000 00000111 11111111 11111111 11111111 11011011 [0x8D] Wls programming key response	  // Set RF jamming zone 07 in [804][93] subsection
  *  Byte 0   1    2        3        4        5        6        7        8        9
  */
 void dscKeybusInterface::printPanel_0x8D() {
-  stream->print(F("User code programming key response"));
+  stream->print(F("Wls programming key response"));
 }
 
 
@@ -3354,41 +3388,41 @@ void dscKeybusInterface::printModule_KeyCodes(byte keyByte) {
     case 0x1C: printNumberSpace(7); break;
     case 0x22: printNumberSpace(8); break;
     case 0x27: printNumberSpace(9); break;
-    case 0x28: stream->print(F("* ")); break;
-    case 0x2D: stream->print(F("# ")); break;
-    case 0x46: stream->print(F("Wireless key disarm ")); break;
-    case 0x52: stream->print(F("Identified voice prompt help ")); break;
-    case 0x6E: stream->print(F("Global away arm ")); break;
-    case 0x70: stream->print(F("Command output 3 ")); break;
-    case 0x7A: stream->print(F("Time and date programming ")); break;
-    case 0x75: stream->print(F("Entered *1/*2/*3 menu (?) ")); break;
-    case 0x82: stream->print(F("Enter ")); break;
-    case 0x87: stream->print(F("Right arrow ")); break;
-    case 0x88: stream->print(F("Left arrow ")); break;
-    case 0x8D: stream->print(F("Bypass recall ")); break;
-    case 0x93: stream->print(F("Recall bypass group ")); break;
-    case 0x94: stream->print(F("Label broadcast announce ")); break;
-    case 0x99: stream->print(F("Function key [25] Future Use ")); break;
-    case 0xA5: stream->print(F("Data successfully received ")); break;
-    case 0xAF: stream->print(F("Arm: Stay ")); break;
-    case 0xB1: stream->print(F("Arm: Away ")); break;
-    case 0xB6: stream->print(F("Arm: No entry delay ")); break;
-    case 0xBB: stream->print(F("Door chime configuration ")); break;
-    case 0xBC: stream->print(F("*6 System test ")); break;
-    case 0xC3: stream->print(F("*1 Zone bypass programming ")); break;
-    case 0xC4: stream->print(F("*2 Trouble menu ")); break;
-    case 0xC9: stream->print(F("*3 Alarm memory display ")); break;
-    case 0xCE: stream->print(F("*5 Programming ")); break;
-    case 0xD0: stream->print(F("*6 Programming ")); break;
-    case 0xD5: stream->print(F("Command output 1 ")); break;
-    case 0xDA: stream->print(F("Reset / Command output 2 ")); break;
-    case 0xDF: stream->print(F("Global stay arm ")); break; //General voice prompt help on panels v4.1 and below
-    case 0xE1: stream->print(F("Quick exit ")); break;
-    case 0xE6: stream->print(F("Activate stay/away zones ")); break;
-    case 0xEB: stream->print(F("LCD display pixel test ")); break;
-    case 0xEC: stream->print(F("Command output 4 ")); break;
-    case 0xF2: stream->print(F("Global disarm ")); break;
-    case 0xF7: stream->print(F("Menu navigation ")); break;
+    case 0x28: stream->print(F("*")); break;
+    case 0x2D: stream->print(F("#")); break;
+    case 0x46: stream->print(F("Wireless key disarm")); break;
+    case 0x52: stream->print(F("Identified voice prompt help")); break;
+    case 0x6E: stream->print(F("Global away arm")); break;
+    case 0x70: stream->print(F("Command output 3")); break;
+    case 0x7A: stream->print(F("Time and date programming")); break;
+    case 0x75: stream->print(F("Entered *1/*2/*3 ?")); break;
+    case 0x82: stream->print(F("Enter")); break;
+    case 0x87: stream->print(F("Right arrow")); break;
+    case 0x88: stream->print(F("Left arrow")); break;
+    case 0x8D: stream->print(F("Bypass recall")); break;
+    case 0x93: stream->print(F("Recall bypass group")); break;
+    case 0x94: stream->print(F("Label broadcast announce")); break;
+    case 0x99: stream->print(F("Function key [25] Future Use")); break;
+    case 0xA5: stream->print(F("Data successfully received")); break;
+    case 0xAF: stream->print(F("Arm: Stay")); break;
+    case 0xB1: stream->print(F("Arm: Away")); break;
+    case 0xB6: stream->print(F("Arm: No entry delay")); break;
+    case 0xBB: stream->print(F("Door chime configuration")); break;
+    case 0xBC: stream->print(F("*6 System test")); break;
+    case 0xC3: stream->print(F("*1 Zone bypass programming")); break;
+    case 0xC4: stream->print(F("*2 Trouble menu")); break;
+    case 0xC9: stream->print(F("*3 Alarm memory display")); break;
+    case 0xCE: stream->print(F("*5 Programming")); break;
+    case 0xD0: stream->print(F("*6 Programming")); break;
+    case 0xD5: stream->print(F("Command output 1")); break;
+    case 0xDA: stream->print(F("Reset / Command output 2")); break;
+    case 0xDF: stream->print(F("Global stay arm")); break;
+    case 0xE1: stream->print(F("Quick exit")); break;
+    case 0xE6: stream->print(F("Activate stay/away zones")); break;
+    case 0xEB: stream->print(F("LCD pixel test")); break;
+    case 0xEC: stream->print(F("Command output 4")); break;
+    case 0xF2: stream->print(F("Global disarm")); break;
+    case 0xF7: stream->print(F("Menu navigation")); break;
   }
 }
 


### PR DESCRIPTION
As discussed in #175 I've decoded User code range 35-95 present on new panels.
Placing Pull request instead of logs output, should be faster and easier for both :)
Tested for: *1, *2, *3, *5, *6, *7, *9, Arm/disarm, random access codes in range 1-75.
Just for reference, Zone expander 7 supervisory and *5/*6 access by users 41-42 already decoded in previous pull request which is already merged.

Changes:
Seperated printPanelStatus1X as it conflicted between 0x14, 0x17 and 0x1B.
Added printPanelStatus5 (for arm/disarm/*9 user codes 35-95 except 40-42)
Added printPanelStatus18 (*5 and *6 users 1-95, *7/Auto-arm cancel users 35-95)
Added `accessCodeIncrease` boolean onto `printPanelAccessCode`, making support for user codes 33-39 and consecutive decoding for users 33-95 by increment of 3 starting with user40, for `printPanelData5,17,18` used on `0xEB` and `0xEC` cmds.

EDIT: in commit b20d79a I've included two new decoded messages, for entering 6-code installer code and 6-code user codes.
EDIT2: in commit 92d0a00 more messages are decoded, for key ouput. Global label broadcast and Data received confirmation as seen in #184 logs
EDIT3: in commit 06cbfc0 0x87 fully decoded as per #166 "Battery check in progress" message decoded aswell.
EDIT4: in commit b4961fa 0xC3 cmd bits3&4 decoded - it is used for dialing attemps and dialer attempt end.
EDIT5: in commit 00f2a51 PGM2 input supervisory trouble/restore for printPanelStatus0 is decoded.
EDIT6: in commit e256c2d added decoding for Event buffer 75% full as well as few new keypad function keys added.
EDIT7: Decoded few new status/panel messages. More info on 0x8D cmd. Added new messages to VirtualKeypad examples.

NOTE: `printPanelAccessCode` need to check panel version before making prefixes for user codes 33, 34, 41 and 42.
Panels with version 4.1 and below have preset user codes 33,34 as Duress and 41,42 as Supervisory.
On panels with version 4.2 and above, only user code 40 is preset as Master, other ones can be individualy set as duress/supervisory.

Also, `processPanelStatus5` should be added in `dscKeybusProcessData.cpp` for following which user code (in range 35-95) armed/disarmed system in sketches.

KeybusReader sketch compiles and flashes fine for Arduino Uno (output from latest commit 8b4caeb):
```
Sketch uses 32256 bytes (100%) of program storage space. Maximum is 32256 bytes.
Global variables use 961 bytes (46%) of dynamic memory, leaving 1087 bytes for local variables. Maximum is 2048 bytes.
```