### PR TITLE
Adding missing default values during init.

### DIFF
--- a/src/dscKeybus.h
+++ b/src/dscKeybus.h
@@ -109,11 +109,11 @@ class dscKeybusInterface {
     bool ready[dscPartitions], readyChanged[dscPartitions];
     bool disabled[dscPartitions], disabledChanged[dscPartitions];
     bool armed[dscPartitions], armedAway[dscPartitions], armedStay[dscPartitions];
-    bool noEntryDelay[dscPartitions], armedChanged[dscPartitions];
-    bool alarm[dscPartitions], alarmChanged[dscPartitions];
-    bool exitDelay[dscPartitions], exitDelayChanged[dscPartitions];
-    byte exitState[dscPartitions], exitStateChanged[dscPartitions];
-    bool entryDelay[dscPartitions], entryDelayChanged[dscPartitions];
+    bool noEntryDelay[dscPartitions], armedChanged[dscPartitions];    // noEntryDelay = armed Night
+    bool alarm[dscPartitions], alarmChanged[dscPartitions];           // Is alarm triggered for partition?
+    bool exitDelay[dscPartitions], exitDelayChanged[dscPartitions];   // Is Exit Delay in progress?
+    byte exitState[dscPartitions], exitStateChanged[dscPartitions];   // Exit Delay Target State
+    bool entryDelay[dscPartitions], entryDelayChanged[dscPartitions]; // Is Entry Delay in progress?
     bool fire[dscPartitions], fireChanged[dscPartitions];
     bool openZonesStatusChanged;
     byte openZones[dscZones], openZonesChanged[dscZones];    // Zone status is stored in an array using 1 bit per zone, up to 64 zones

--- a/src/dscKeybusProcessData.cpp
+++ b/src/dscKeybusProcessData.cpp
@@ -39,10 +39,15 @@ void dscKeybusInterface::resetStatus() {
   batteryChanged = true;
   for (byte partition = 0; partition < dscPartitions; partition++) {
     readyChanged[partition] = true;
+    disabledChanged[partition] = true;
     armedChanged[partition] = true;
     alarmChanged[partition] = true;
+    exitDelayChanged[partition] = true;
+    exitStateChanged[partition] = true;
+    entryDelayChanged[partition] = true;
     fireChanged[partition] = true;
     disabled[partition] = true;
+    noEntryDelay[partition] = false;
   }
   openZonesStatusChanged = true;
   alarmZonesStatusChanged = true;
@@ -50,6 +55,7 @@ void dscKeybusInterface::resetStatus() {
     openZonesChanged[zoneGroup] = 0xFF;
     alarmZonesChanged[zoneGroup] = 0xFF;
   }
+  pgmOutputsStatusChanged = true;
   pgmOutputsChanged[0] = 0xFF;
   pgmOutputsChanged[1] = 0x3F;
 }


### PR DESCRIPTION
Some of the "changed" variables were not re-initialized properly causing invalid states.