### PR TITLE
Set time variables only on timestamp message.

### DIFF
--- a/src/dscKeybusProcessData.cpp
+++ b/src/dscKeybusProcessData.cpp
@@ -499,10 +499,9 @@ void dscKeybusInterface::processPanel_0x87() {
 void dscKeybusInterface::processPanel_0xA5() {
   if (!validCRC()) return;
 
-  processTime(2);
-
   // Timestamp
   if (panelData[6] == 0 && panelData[7] == 0) {
+    processTime(2);
     statusChanged = true;
     timestampChanged = true;
     return;
@@ -579,7 +578,13 @@ void dscKeybusInterface::processPanel_0xEB() {
   if (!validCRC()) return;
   if (dscPartitions < 3) return;
 
-  processTime(3);
+  // Timestamp
+  if (panelData[6] == 0 && panelData[7] == 0) {
+    processTime(3);
+    statusChanged = true;
+    timestampChanged = true;
+    return;
+  }
 
   byte partition;
   switch (panelData[2]) {


### PR DESCRIPTION
Without this, `dsc.year`, `dsc.month`, `dsc.hour` and `dsc.minute` becomes messed up. This ensure the time-related variables are only changed when a Timestamp message arrives, which is every 240 seconds (4 minutes) on a PC1832.