### PR TITLE
Add compatibility to Arduino Core 3.0.x and ESP32-IDF 5.xx

### DIFF
--- a/src/dscClassic.cpp
+++ b/src/dscClassic.cpp
@@ -64,12 +64,20 @@ void dscClassicInterface::begin(Stream &_stream) {
   timer1_enable(TIM_DIV16, TIM_EDGE, TIM_SINGLE);
 
   // esp32 timer1 calls dscDataInterrupt() from dscClockInterrupt()
+  
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR >= 5
+  timer1 = timerBegin(1000000);
+  timerStop(timer1);
+  timerAttachInterrupt(timer1, &dscDataInterrupt);
+  timerAlarm(timer1, 250, true, 0);
+  #elif
   timer1 = timerBegin(1, 80, true);
   timerStop(timer1);
   timerAttachInterrupt(timer1, &dscDataInterrupt, true);
   timerAlarmWrite(timer1, 250, true);
   timerAlarmEnable(timer1);
+  #endif
   #endif
 
   // Generates an interrupt when the Keybus clock rises or falls - requires a hardware interrupt pin on Arduino/AVR
@@ -90,7 +98,9 @@ void dscClassicInterface::stop() {
 
   // Disables esp32 timer1
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR < 5
   timerAlarmDisable(timer1);
+  #endif
   timerEnd(timer1);
   #endif
 

--- a/src/dscClassicKeypad.cpp
+++ b/src/dscClassicKeypad.cpp
@@ -61,12 +61,21 @@ void dscClassicKeypadInterface::begin(Stream &_stream) {
   timer1_write(5000);
 
   // esp32 timer1 calls dscClockInterrupt()
+
+
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR >= 5
+  timer1 = timerBegin(1000000);
+  timerStop(timer1);
+  timerAttachInterrupt(timer1, &dscClockInterrupt);
+  timerAlarm(timer1, 1000, true, 0);
+  #elif
   timer1 = timerBegin(1, 80, true);
   timerStop(timer1);
   timerAttachInterrupt(timer1, &dscClockInterrupt, true);
   timerAlarmWrite(timer1, 1000, true);
   timerAlarmEnable(timer1);
+  #endif
   #endif
 
   intervalStart = millis();

--- a/src/dscKeybusInterface.cpp
+++ b/src/dscKeybusInterface.cpp
@@ -59,11 +59,18 @@ void dscKeybusInterface::begin(Stream &_stream) {
 
   // esp32 timer1 calls dscDataInterrupt() from dscClockInterrupt()
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR >= 5
+  timer1 = timerBegin(1000000);
+  timerStop(timer1);
+  timerAttachInterrupt(timer1, &dscDataInterrupt);
+  timerAlarm(timer1, 250, true, 0);
+  #elif
   timer1 = timerBegin(1, 80, true);
   timerStop(timer1);
   timerAttachInterrupt(timer1, &dscDataInterrupt, true);
   timerAlarmWrite(timer1, 250, true);
   timerAlarmEnable(timer1);
+  #endif
   #endif
 
   // Generates an interrupt when the Keybus clock rises or falls - requires a hardware interrupt pin on Arduino/AVR
@@ -84,7 +91,9 @@ void dscKeybusInterface::stop() {
 
   // Disables esp32 timer1
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR < 5
   timerAlarmDisable(timer1);
+  #endif
   timerEnd(timer1);
   #endif
 

--- a/src/dscKeybusReader.cpp
+++ b/src/dscKeybusReader.cpp
@@ -59,11 +59,18 @@ void dscKeybusReaderInterface::begin(Stream &_stream) {
 
   // esp32 timer1 calls dscDataInterrupt() from dscClockInterrupt()
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR >= 5
+  timer1 = timerBegin(1000000);
+  timerStop(timer1);
+  timerAttachInterrupt(timer1, &dscDataInterrupt);
+  timerAlarm(timer1, 250, true, 0);
+  #elif
   timer1 = timerBegin(1, 80, true);
   timerStop(timer1);
   timerAttachInterrupt(timer1, &dscDataInterrupt, true);
   timerAlarmWrite(timer1, 250, true);
   timerAlarmEnable(timer1);
+  #endif
   #endif
 
   // Generates an interrupt when the Keybus clock rises or falls - requires a hardware interrupt pin on Arduino/AVR
@@ -84,7 +91,9 @@ void dscKeybusReaderInterface::stop() {
 
   // Disables esp32 timer1
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR < 5
   timerAlarmDisable(timer1);
+  #endif
   timerEnd(timer1);
   #endif
 

--- a/src/dscKeypad.cpp
+++ b/src/dscKeypad.cpp
@@ -62,11 +62,18 @@ void dscKeypadInterface::begin(Stream &_stream) {
 
   // esp32 timer1 calls dscClockInterrupt()
   #elif defined(ESP32)
+  #if ESP_IDF_VERSION_MAJOR >= 5
+  timer1 = timerBegin(1000000);
+  timerStop(timer1);
+  timerAttachInterrupt(timer1, &dscClockInterrupt);
+  timerAlarm(timer1, 500, true, 0);
+  #elif
   timer1 = timerBegin(1, 80, true);
   timerStop(timer1);
   timerAttachInterrupt(timer1, &dscClockInterrupt, true);
   timerAlarmWrite(timer1, 500, true);
   timerAlarmEnable(timer1);
+  #endif
   #endif
 
   intervalStart = millis();


### PR DESCRIPTION
There are some breaking changes in ESP32 Arduino core 2.x to 3.0 in Timer API:
https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html

Add IDF version check and compatible timer setting.

Tested on ESP32 and DSC PC1616, all functions working.